### PR TITLE
lnls-ans-role-users: fix sudoers to disallow passwordless sudo

### DIFF
--- a/roles/lnls-ans-role-users/tasks/grant-root.yml
+++ b/roles/lnls-ans-role-users/tasks/grant-root.yml
@@ -9,7 +9,7 @@
     dest: /etc/sudoers
     state: present
     regexp: '^%{{ root_group }}'
-    line: '%{{ root_group }} ALL=(ALL) NOPASSWD: ALL'
+    line: '%{{ root_group }} ALL=(ALL:ALL) ALL'
     validate: visudo -cf %s
 
 - name: Add sudoers users to {{ root_group }} group


### PR DESCRIPTION
Fix sudoers file modification in lnls-ans-role-users to disallow passwordless sudo