### PR TITLE
Remove dependencies

### DIFF
--- a/roles/lnls-ans-role-cs-studio/meta/main.yml
+++ b/roles/lnls-ans-role-cs-studio/meta/main.yml
@@ -20,6 +20,6 @@ galaxy_info:
         - bionic
 
 dependencies:
-  - lnls-ans-role-java
-  - lnls-ans-role-python
-  - lnls-ans-role-phoebus
+  # - lnls-ans-role-java
+  # - lnls-ans-role-python
+  # - lnls-ans-role-phoebus

--- a/roles/lnls-ans-role-desktop-apps/meta/main.yml
+++ b/roles/lnls-ans-role-desktop-apps/meta/main.yml
@@ -26,5 +26,5 @@ galaxy_info:
         - bionic
 
 dependencies:
-  - lnls-ans-role-repositories
-  - lnls-ans-role-users
+  # - lnls-ans-role-repositories
+  # - lnls-ans-role-users

--- a/roles/lnls-ans-role-epics/meta/main.yml
+++ b/roles/lnls-ans-role-epics/meta/main.yml
@@ -18,5 +18,5 @@ galaxy_info:
         - trusty
 
 dependencies:
-  - lnls-ans-role-repositories
-  - lnls-ans-role-python
+  # - lnls-ans-role-repositories
+  # - lnls-ans-role-python

--- a/roles/lnls-ans-role-phoebus/meta/main.yml
+++ b/roles/lnls-ans-role-phoebus/meta/main.yml
@@ -20,6 +20,6 @@ galaxy_info:
         - bionic
 
 dependencies:
-  - lnls-ans-role-users
-  - lnls-ans-role-java
-  - lnls-ans-role-repositories
+  # - lnls-ans-role-users
+  # - lnls-ans-role-java
+  # - lnls-ans-role-repositories

--- a/roles/lnls-ans-role-pydm/meta/main.yml
+++ b/roles/lnls-ans-role-pydm/meta/main.yml
@@ -26,6 +26,6 @@ galaxy_info:
         - bionic
 
 dependencies:
-  - lnls-ans-role-python
-  - lnls-ans-role-epics
-  - lnls-ans-role-qt
+  # - lnls-ans-role-python
+  # - lnls-ans-role-epics
+  # - lnls-ans-role-qt

--- a/roles/lnls-ans-role-qt/meta/main.yml
+++ b/roles/lnls-ans-role-qt/meta/main.yml
@@ -26,4 +26,4 @@ galaxy_info:
         - bionic
 
 dependencies:
-  - lnls-ans-role-python
+  # - lnls-ans-role-python

--- a/roles/lnls-ans-role-sirius-apps/meta/main.yml
+++ b/roles/lnls-ans-role-sirius-apps/meta/main.yml
@@ -26,8 +26,8 @@ galaxy_info:
         - bionic
 
 dependencies:
-  - lnls-ans-role-users
-  - lnls-ans-role-python
-  - lnls-ans-role-epics
-  - lnls-ans-role-qt
-  - lnls-ans-role-pydm
+  # - lnls-ans-role-users
+  # - lnls-ans-role-python
+  # - lnls-ans-role-epics
+  # - lnls-ans-role-qt
+  # - lnls-ans-role-pydm

--- a/roles/lnls-ans-role-zabbix/meta/main.yml
+++ b/roles/lnls-ans-role-zabbix/meta/main.yml
@@ -20,4 +20,4 @@ galaxy_info:
         - bionic
 
 dependencies:
-  - lnls-ans-role-repositories
+  # - lnls-ans-role-repositories


### PR DESCRIPTION
Removing the dependencies speed up the running time by a factor of two with a single host already synchronized. 

Instead of removing the dependencies, I tried to import them with a condition which checked if they had already run (like this:
```dependencies:
  - { role: 'xcode', when: ansible_os_family == 'Darwin' }

```
), but the result was not as I expected.

Maybe in the future we could study a better way of including dependencies...