### PR TITLE
lnls-ans-role-epics: add pcaspy and epics python2 packages

### DIFF
--- a/roles/lnls-ans-role-epics/tasks/main.yml
+++ b/roles/lnls-ans-role-epics/tasks/main.yml
@@ -40,6 +40,12 @@
     pip_executable: "{{ __pip_executable | default(omit) }}"
   when: pip_executable is not defined
 
+- name: Define PIP Python2 executable
+  set_fact:
+    pip2_executable: "{{ __pip2_executable | default(omit) }}"
+  when: pip2_executable is not defined
+
+
 # Setup/install tasks
 - include_tasks: setup-Debian.yml
   when:

--- a/roles/lnls-ans-role-epics/tasks/setup-Debian.yml
+++ b/roles/lnls-ans-role-epics/tasks/setup-Debian.yml
@@ -46,6 +46,20 @@
   retries: 5
   delay: 2
 
+- name: Ensure Python2 EPICS packages are installed
+  pip:
+    name: "{{ epics_pip_packages }}"
+    state: "{{ epics_pip_packages_state }}"
+    executable: "{{ pip2_executable }}"
+  environment:
+    EPICS_BASE: "{{ epics_base_dir }}"
+    EPICS_HOST_ARCH: "{{ epics_host_arch }}"
+  become: true
+  register: epics_pip_packages_result
+  until: epics_pip_packages_result is success
+  retries: 5
+  delay: 2
+
 - name: Ensure EPICS environment is installed
   template:
     src: "{{ item.filename }}.j2"

--- a/roles/lnls-ans-role-epics/vars/Debian-buster.yml
+++ b/roles/lnls-ans-role-epics/vars/Debian-buster.yml
@@ -9,3 +9,5 @@ __epics_pip_packages:
   - pcaspy=={{ pkg_version_pcaspy }}
 
 __pip_executable: pip-sirius
+
+__pip2_executable: pip

--- a/roles/lnls-ans-role-epics/vars/Debian-jessie.yml
+++ b/roles/lnls-ans-role-epics/vars/Debian-jessie.yml
@@ -9,3 +9,5 @@ __epics_pip_packages:
   - pcaspy=={{ pkg_version_pcaspy }}
 
 __pip_executable: pip-sirius
+
+__pip2_executable: pip

--- a/roles/lnls-ans-role-epics/vars/Debian-stretch.yml
+++ b/roles/lnls-ans-role-epics/vars/Debian-stretch.yml
@@ -14,3 +14,5 @@ __epics_pip_packages:
   - pcaspy=={{ pkg_version_pcaspy }}
 
 __pip_executable: pip-sirius
+
+__pip2_executable: pip

--- a/roles/lnls-ans-role-epics/vars/Debian.yml
+++ b/roles/lnls-ans-role-epics/vars/Debian.yml
@@ -9,3 +9,5 @@ __epics_pip_packages:
   - pcaspy
 
 __pip_executable: pip-sirius
+
+__pip2_executable: pip

--- a/roles/lnls-ans-role-epics/vars/Ubuntu-bionic.yml
+++ b/roles/lnls-ans-role-epics/vars/Ubuntu-bionic.yml
@@ -8,3 +8,5 @@ __epics_pip_packages:
   - pcaspy
 
 __pip_executable: pip-sirius
+
+__pip2_executable: pip

--- a/roles/lnls-ans-role-epics/vars/Ubuntu-trusty.yml
+++ b/roles/lnls-ans-role-epics/vars/Ubuntu-trusty.yml
@@ -8,3 +8,5 @@ __epics_pip_packages:
   - pcaspy
 
 __pip_executable: pip-sirius
+
+__pip2_executable: pip

--- a/roles/lnls-ans-role-epics/vars/Ubuntu-xenial.yml
+++ b/roles/lnls-ans-role-epics/vars/Ubuntu-xenial.yml
@@ -8,3 +8,5 @@ __epics_pip_packages:
   - pcaspy
 
 __pip_executable: pip-sirius
+
+__pip2_executable: pip


### PR DESCRIPTION
so as to allow linac PS iocs to run in any server.