### PR TITLE
playbooks: add users task to tasks-desktops-sirius.yml

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -2,3 +2,4 @@
 inventory = ./hosts
 host_key_checking = False
 roles_path = roles
+forks = 400

--- a/tasks-desktops-sirius.yml
+++ b/tasks-desktops-sirius.yml
@@ -1,5 +1,7 @@
 ---
 - import_role:
+    name: lnls-ans-role-users
+- import_role:
     name: lnls-ans-role-sirius-apps
 - import_role:
     name: lnls-ans-role-desktop-apps


### PR DESCRIPTION
- added role defines missing *user* variable