### PR TITLE
Pr add role network

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -1,7 +1,7 @@
 ---
 
 nfs_server_control_room: 10.128.1.3
-nfs_server_control_opi: 10.128.1.3
+nfs_server_control_opi: 10.128.255.9
 
 fac_workstation_ip: 10.0.7.55
 nfs_clients_control_room_subnet: 10.128.254.0/24

--- a/roles/lnls-ans-role-network/.flake8
+++ b/roles/lnls-ans-role-network/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+ignore = E501

--- a/roles/lnls-ans-role-network/.gitignore
+++ b/roles/lnls-ans-role-network/.gitignore
@@ -1,0 +1,9 @@
+.molecule
+.vagrant
+.cache
+*.swp
+.DS_Store
+__pycache__
+*.pyc
+*.log
+playbook.retry

--- a/roles/lnls-ans-role-network/.yamllint
+++ b/roles/lnls-ans-role-network/.yamllint
@@ -1,0 +1,13 @@
+extends: default
+
+rules:
+  braces:
+    max-spaces-inside: 1
+    level: error
+  brackets:
+    max-spaces-inside: 1
+    level: error
+  line-length: disable
+  # NOTE(retr0h): Templates no longer fail this lint rule.
+  #               Uncomment if running old Molecule templates.
+  # truthy: disable

--- a/roles/lnls-ans-role-network/LICENSE
+++ b/roles/lnls-ans-role-network/LICENSE
@@ -1,0 +1,25 @@
+BSD 2-Clause License
+
+Copyright (c) 2019, Brazilian Synchrotron Light Laboratory LNLS
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/roles/lnls-ans-role-network/README.md
+++ b/roles/lnls-ans-role-network/README.md
@@ -1,0 +1,113 @@
+LNLS Ansible Role for Network
+=======================
+
+This Ansible role configures some network parameters for Sirius Light Source control machines.
+
+## Requirements
+
+- ansible >= 2.4
+- molecule >= 2.20
+
+## Role Variables
+
+```yaml
+---
+# Package versions for Debia. Leave empty for the latest
+pkg_network_manager_version: ""
+pkg_python_dbus_version: ""
+pkg_python3_dbus_version: ""
+pkg_libnm_glib_dev_version: ""
+
+# Package versions for Fedora-like. Leave empty for the latest
+pkg_network_manager_glib_version: ""
+pkg_libnm_qt_devel_version: ""
+pkg_nm_connection_editor_version: ""
+pkg_libsemanage_python_version: ""
+pkg_policycoreutils_python_version: ""
+
+# Set this to true when using this in a regular,
+# without systemd support.
+network_ignore_systemd_errors: false
+
+network_interfaces:
+  - name: TIC
+    ignore_auto_dns: "true"
+
+  - name: CONS
+    ignore_auto_dns: "false"
+
+```
+
+## Example Playbook
+
+```yaml
+---
+- hosts: all
+  tasks:
+  - import_role:
+      name: '{{playbook_dir}}'
+```
+
+## Example Commmand
+
+```bash
+ansible-playbook -i host, -u user -k --ask-become-pass playbook.yml
+```
+
+## Tests
+
+Tests are performed using Molecule. To run them with python virtualenv, issue:
+
+```bash
+    bash -c "\
+        cd ../ && \
+        virtualenv env --python python3 && \
+        source env/bin/activate && \
+        cd lnls-ans-role-network && \
+        pip install molecule docker-py && \
+        molecule test"
+```
+
+Optionally, you can specify dns servers to be used for both
+provisioner create and run (docker in our case), by using
+the following variables:
+
+
+```bash
+    export DNS_SERVER1="<DNS server 1>"
+    export DNS_SERVER2="<DNS server 2>"
+```
+
+This can be used, for instance, in hosts that have non-default
+DNS configurations that docker can't access, such as when
+using local systemd-resolv DNS (e.g., 127.x.y.z) or when DNS
+servers are set via DHCP with local non-routable IP addresses
+(e.g., 10.x.y.z).
+
+## Troubleshooting
+
+If you use a host system with SELinux enabled you might get an error when using
+Ansible like the following:
+
+```bash
+    "msg": "Aborting, target uses selinux but python bindings (libselinux-python) aren't installed!"
+```
+
+If that happens, it might be because virtualenv does not have access to libselinux
+and it can't be installed via pip.
+
+A workaround might be to manually copy the librar files into the virtualenv
+so that Ansible has access to it.
+
+On a Fedra 29 system, using python3-7, the following fixes the issue:
+
+```bash
+    cp -r /usr/lib64/python3.7/site-packages/selinux env/lib64/python3.7/site-packages/
+    cp -r /usr/lib64/python3.7/site-packages/_selinux.cpython-37m-x86_64-linux-gnu.so env/lib64/python3.7/site-packages/
+```
+
+Be advised, that the python versions might differ and the library names, as well.
+
+## License
+
+BSD 2-clause

--- a/roles/lnls-ans-role-network/Vagrant/README.md
+++ b/roles/lnls-ans-role-network/Vagrant/README.md
@@ -1,0 +1,46 @@
+Vagrant Testing
+=======================
+
+This Vagrant directory contains the necessary infrastructure to test
+ansible roles in Vagrant boxes.
+
+Four environments are provided: Debian Stretch, Debian Jessie, Ubuntu Trusty
+and Ubuntu Xenial.
+
+## Instructions
+
+Start vagrant boxes by issuing:
+
+```bash
+    vagrant up
+```
+
+Or by selecting only one of them:
+
+```bash
+    vagrant up debian.stretch
+```
+
+Run a basic ansible playbook to configure the SSH keys on the vagrant box:
+
+```bash
+    ansible-playbook -i hosts -u vagrant setup.yml
+```
+
+Or by selecting only one of them:
+
+```bash
+    ansible-playbook -i hosts -l debian.stretch -u vagrant setup.yml
+```
+
+Run the playbook agains the boxes:
+
+```bash
+    ansible-playbook -i hosts -u vagrant ../molecule/default/playbook.yml
+```
+
+Or by selecting only one of them:
+
+```bash
+    ansible-playbook -i hosts -l debian.stretch -u vagrant ../molecule/default/playbook.yml
+```

--- a/roles/lnls-ans-role-network/Vagrant/Vagrantfile
+++ b/roles/lnls-ans-role-network/Vagrant/Vagrantfile
@@ -1,0 +1,37 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+hosts = {
+  "debian.jessie"  => "192.168.33.10",
+  "debian.stretch" => "192.168.33.11",
+  "debian.buster"  => "192.168.33.12",
+  "ubuntu.trusty"  => "192.168.33.13",
+  "ubuntu.xenial"  => "192.168.33.14",
+  "centos.7"  => "192.168.33.15",
+}
+
+Vagrant.configure("2") do |config|
+  hosts.each do |name, ip|
+    config.vm.define name do |machine|
+      if name.eql? "debian.jessie" then
+        machine.vm.box = "debian/jessie64"
+      elsif name.eql? "debian.stretch" then
+        machine.vm.box = "debian/stretch64"
+      elsif name.eql? "debian.buster" then
+        machine.vm.box = "debian/buster64"
+      elsif name.eql? "ubuntu.xenial" then
+        machine.vm.box = "ubuntu/xenial64"
+      elsif name.eql? "ubuntu.trusty" then
+        machine.vm.box = "ubuntu/trusty64"
+      elsif name.eql? "centos.7" then
+        machine.vm.box = "centos/7"
+      end
+      machine.vm.hostname = "%s" % name
+      machine.vm.network :private_network, ip: ip
+      machine.vm.provider "virtualbox" do |v|
+          v.name = name
+          v.customize ["modifyvm", :id, "--memory", 256]
+      end
+    end
+  end
+end

--- a/roles/lnls-ans-role-network/Vagrant/hosts
+++ b/roles/lnls-ans-role-network/Vagrant/hosts
@@ -1,0 +1,9 @@
+debian.jessie  ansible_host=192.168.33.10
+debian.stretch ansible_host=192.168.33.11
+debian.buster  ansible_host=192.168.33.12
+ubuntu.trusty  ansible_host=192.168.33.13
+ubuntu.xenial  ansible_host=192.168.33.14
+centos.7       ansible_host=192.168.33.15
+
+[all:vars]
+ansible_ssh_private_key_file=.vagrant/machines/{{ inventory_hostname }}/virtualbox/private_key

--- a/roles/lnls-ans-role-network/Vagrant/setup.yml
+++ b/roles/lnls-ans-role-network/Vagrant/setup.yml
@@ -1,0 +1,94 @@
+---
+- hosts: all
+  become: true
+  become_user: root
+  remote_user: vagrant
+  gather_facts: true
+  tasks:
+    # This should work too / #2372
+    # - name: Pushes user key to root's on vagrant boxes
+    #   action: authorized_key key=$FILE($item) user=root
+    #   first_available_file:
+    #     - ~/.ssh/id_dsa.pub
+    #     - ~/.ssh/id_rsa.pub
+
+    - name: Wait for ssh to be up
+      become: false
+      wait_for:
+        port: 22
+        delay: 5
+        connect_timeout: 5
+        timeout: 360
+        host: "{{ ansible_host }}"
+      delegate_to: localhost
+
+    - name: Installs python for Debian based distros
+      apt:
+        name: python
+        state: present
+      become: true
+      register: apt_result
+      until: apt_result is success
+      retries: 5
+      delay: 2
+      when: ansible_os_family == 'Debian'
+
+    - name: Installs python for RedHat based distros
+      package:
+        name: python
+        state: present
+      become: true
+      register: package_result
+      until: package_result is success
+      retries: 5
+      delay: 2
+      when: ansible_os_family == 'RedHat'
+
+    - name: Creates destination directory
+      # Workaround for #2372
+      file:
+        state: directory
+        mode: 0700
+        dest: /root/.ssh/
+
+    - name: Pushes user's rsa key to root's vagrant box (it's ok if this TASK fails)
+      # action: authorized_key user=root key='$FILE(~/.ssh/id_rsa.pub)'
+      # Workaround for #2372
+      copy:
+        src: ~/.ssh/id_rsa.pub
+        dest: /root/.ssh/authorized_keys
+        owner: root
+        mode: 0600
+      register: rsa
+      ignore_errors: true
+
+    - name: Pushes user's dsa key to root's vagrant box (it's NOT ok if both TASKs fail)
+      # action: authorized_key user=root key='$FILE(~/.ssh/id_dsa.pub)'
+      # Workaround for #2372
+      copy:
+        src: ~/.ssh/id_dsa.pub
+        dest: /root/.ssh/authorized_keys
+        owner: root
+        mode: 0600
+      when: rsa is failed
+
+    - name: Checks if resolver is working properly (issues with some VBox/Host OS combinations)
+      command: host -t A ansible.cc
+      register: ns
+      ignore_errors: true
+
+    - name: Pushes new resolver configuration if resolver fails
+      lineinfile:
+        regexp: "^nameserver "
+        line: "nameserver 8.8.8.8"
+        dest: /etc/resolv.conf
+      when: ns is failed
+
+    - name: Checks if resolver is working properly with new nameserver
+      command: host -t A ansible.cc
+
+    - name: Final greeting
+      pause:
+        seconds: 1
+        echo: false
+        prompt: "Don't worry about all the red above; if you made it here, your Vagrant VMs are probably fine !"

--- a/roles/lnls-ans-role-network/defaults/main.yml
+++ b/roles/lnls-ans-role-network/defaults/main.yml
@@ -1,0 +1,24 @@
+---
+# Package versions for Debia. Leave empty for the latest
+pkg_network_manager_version: ""
+pkg_python_dbus_version: ""
+pkg_python3_dbus_version: ""
+pkg_libnm_glib_dev_version: ""
+
+# Package versions for Fedora-like. Leave empty for the latest
+pkg_network_manager_glib_version: ""
+pkg_libnm_qt_devel_version: ""
+pkg_nm_connection_editor_version: ""
+pkg_libsemanage_python_version: ""
+pkg_policycoreutils_python_version: ""
+
+# Set this to true when using this in a regular,
+# without systemd support.
+network_ignore_systemd_errors: false
+
+network_interfaces:
+  - name: TIC
+    ignore_auto_dns: "true"
+
+  - name: CONS
+    ignore_auto_dns: "false"

--- a/roles/lnls-ans-role-network/handlers/main.yml
+++ b/roles/lnls-ans-role-network/handlers/main.yml
@@ -1,0 +1,15 @@
+---
+- name: Restart Network Manager systemd service
+  block:
+    - name: Restart Network Manager systemd service
+      systemd:
+        name: NetworkManager
+        state: restarted
+  become: true
+  ignore_errors: "{{ network_ignore_systemd_errors }}"
+  rescue:
+    - name: Show warning to user if systemd fails
+      pause:
+        seconds: 1
+        echo: false
+        prompt: "Could not restart NetworkManager systemd service. Probably running in Docker? Continuing anyway ..."

--- a/roles/lnls-ans-role-network/meta/main.yml
+++ b/roles/lnls-ans-role-network/meta/main.yml
@@ -1,0 +1,28 @@
+---
+galaxy_info:
+  author: Lucas Russo
+  description: Ansible role to configure Network
+  company: CNPEM - LNLS
+  license: BSD
+  min_ansible_version: 2.4
+
+  platforms:
+    - name: EL
+      versions:
+        - 6
+        - 7
+    - name: Fedora
+      versions:
+        - all
+    - name: Debian
+      versions:
+        - jessie
+        - stretch
+    - name: Ubuntu
+      versions:
+        - precise
+        - trusty
+        - xenial
+        - bionic
+
+dependencies: []

--- a/roles/lnls-ans-role-network/molecule/default/Dockerfile.j2
+++ b/roles/lnls-ans-role-network/molecule/default/Dockerfile.j2
@@ -1,0 +1,22 @@
+# Molecule managed
+
+{% if item.registry is defined %}
+FROM {{ item.registry.url }}/{{ item.image }}
+{% else %}
+FROM {{ item.image }}
+{% endif %}
+
+RUN \
+{% if item.dns_servers is defined and item.dns_servers %}
+    {% for dns in item.dns_servers %}
+        {% if dns|length %}
+            echo "nameserver {{ dns }}" >> /etc/resolv.conf && \
+        {% endif %}
+    {% endfor %}
+{% endif %}
+    if [ $(command -v apt-get) ]; then apt-get update && apt-get install -y python sudo bash ca-certificates && apt-get clean; \
+    elif [ $(command -v dnf) ]; then dnf makecache && dnf --assumeyes install python sudo python-devel python2-dnf bash && dnf clean all; \
+    elif [ $(command -v yum) ]; then yum makecache fast && yum install -y python sudo yum-plugin-ovl bash && sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf && yum clean all; \
+    elif [ $(command -v zypper) ]; then zypper refresh && zypper install -y python sudo bash python-xml && zypper clean -a; \
+    elif [ $(command -v apk) ]; then apk update && apk add --no-cache python sudo bash ca-certificates; \
+    elif [ $(command -v xbps-install) ]; then xbps-install -Syu && xbps-install -y python sudo bash ca-certificates && xbps-remove -O; fi

--- a/roles/lnls-ans-role-network/molecule/default/README.md
+++ b/roles/lnls-ans-role-network/molecule/default/README.md
@@ -1,0 +1,16 @@
+*******
+Docker driver installation guide
+*******
+
+Requirements
+============
+
+* General molecule dependencies (see https://molecule.readthedocs.io/en/latest/installation.html)
+* Docker Engine
+* docker-py
+* docker
+
+Install
+=======
+
+    $ sudo pip install docker-py

--- a/roles/lnls-ans-role-network/molecule/default/create.yml
+++ b/roles/lnls-ans-role-network/molecule/default/create.yml
@@ -1,0 +1,104 @@
+---
+- name: Create
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  no_log: "{{ not (lookup('env', 'MOLECULE_DEBUG') | bool or molecule_yml.provisioner.log|default(false) | bool) }}"
+  tasks:
+    - name: Log into a Docker registry
+      docker_login:
+        username: "{{ item.registry.credentials.username }}"
+        password: "{{ item.registry.credentials.password }}"
+        email: "{{ item.registry.credentials.email | default(omit) }}"
+        registry: "{{ item.registry.url }}"
+        docker_host: "{{ item.docker_host | default(lookup('env', 'DOCKER_HOST') or 'unix://var/run/docker.sock') }}"
+      with_items: "{{ molecule_yml.platforms }}"
+      when:
+        - item.registry is defined
+        - item.registry.credentials is defined
+        - item.registry.credentials.username is defined
+
+    - name: Create Dockerfiles from image names
+      template:
+        src: "{{ molecule_scenario_directory + '/' + (item.dockerfile | default( 'Dockerfile.j2')) }}"
+        dest: "{{ molecule_ephemeral_directory }}/Dockerfile_{{ item.image | regex_replace('[^a-zA-Z0-9_]', '_') }}"
+      with_items: "{{ molecule_yml.platforms }}"
+      when: not item.pre_build_image | default(false)
+      register: platforms
+
+    - name: Discover local Docker images
+      docker_image_facts:
+        name: "molecule_local/{{ item.item.name }}"
+        docker_host: "{{ item.item.docker_host | default(lookup('env', 'DOCKER_HOST') or 'unix://var/run/docker.sock') }}"
+      with_items: "{{ platforms.results }}"
+      when: not item.pre_build_image | default(false)
+      register: docker_images
+
+    - name: Build an Ansible compatible image
+      docker_image:
+        path: "{{ molecule_ephemeral_directory }}"
+        name: "molecule_local/{{ item.item.image }}"
+        docker_host: "{{ item.item.docker_host | default(lookup('env', 'DOCKER_HOST') or 'unix://var/run/docker.sock') }}"
+        dockerfile: "{{ item.invocation.module_args.dest }}"
+        force: "{{ item.item.force | default(true) }}"
+        pull: "{{ item.item.pull | default(omit) }}"
+        buildargs: "{{ item.item.buildargs | default(omit) }}"
+      with_items: "{{ platforms.results }}"
+      when:
+        - platforms.changed or docker_images.results | map(attribute='images') | select('equalto', []) | list | count >= 0
+        - not item.item.pre_build_image | default(false)
+
+    - name: Create docker network(s)
+      docker_network:
+        name: "{{ item }}"
+        docker_host: "{{ item.docker_host | default(lookup('env', 'DOCKER_HOST') or 'unix://var/run/docker.sock') }}"
+        state: present
+      with_items: "{{ molecule_yml.platforms | molecule_get_docker_networks }}"
+
+    - name: Determine the CMD directives
+      set_fact:
+        command_directives_dict: >-
+          {{ command_directives_dict | default({}) |
+             combine({ item.name: item.command | default('bash -c "while true; do sleep 10000; done"') })
+          }}
+      with_items: "{{ molecule_yml.platforms }}"
+      when: item.override_command | default(true)
+
+    - name: Create molecule instance(s)
+      docker_container:
+        name: "{{ item.name }}"
+        docker_host: "{{ item.docker_host | default(lookup('env', 'DOCKER_HOST') or 'unix://var/run/docker.sock') }}"
+        hostname: "{{ item.hostname | default(item.name) }}"
+        image: "{{ item.pre_build_image | default(false) | ternary('', 'molecule_local/') }}{{ item.image }}"
+        state: started
+        recreate: false
+        log_driver: json-file
+        command: "{{ (command_directives_dict | default({}))[item.name] | default(omit) }}"
+        pid_mode: "{{ item.pid_mode | default(omit) }}"
+        privileged: "{{ item.privileged | default(omit) }}"
+        security_opts: "{{ item.security_opts | default(omit) }}"
+        volumes: "{{ item.volumes | default(omit) }}"
+        tmpfs: "{{ item.tmpfs | default(omit) }}"
+        capabilities: "{{ item.capabilities | default(omit) }}"
+        exposed_ports: "{{ item.exposed_ports | default(omit) }}"
+        published_ports: "{{ item.published_ports | default(omit) }}"
+        ulimits: "{{ item.ulimits | default(omit) }}"
+        networks: "{{ item.networks | default(omit) }}"
+        network_mode: "{{ item.network_mode | default(omit) }}"
+        purge_networks: "{{ item.purge_networks | default(omit) }}"
+        dns_servers: "{{ item.dns_servers | default(omit) }}"
+        env: "{{ item.env | default(omit) }}"
+        restart_policy: "{{ item.restart_policy | default(omit) }}"
+        restart_retries: "{{ item.restart_retries | default(omit) }}"
+      register: server
+      with_items: "{{ molecule_yml.platforms }}"
+      async: 7200
+      poll: 0
+
+    - name: Wait for instance(s) creation to complete
+      async_status:
+        jid: "{{ item.ansible_job_id }}"
+      register: docker_jobs
+      until: docker_jobs.finished
+      retries: 300
+      with_items: "{{ server.results }}"

--- a/roles/lnls-ans-role-network/molecule/default/destroy.yml
+++ b/roles/lnls-ans-role-network/molecule/default/destroy.yml
@@ -1,0 +1,32 @@
+---
+- name: Destroy
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  no_log: "{{ not (lookup('env', 'MOLECULE_DEBUG') | bool or molecule_yml.provisioner.log|default(false) | bool) }}"
+  tasks:
+    - name: Destroy molecule instance(s)
+      docker_container:
+        name: "{{ item.name }}"
+        docker_host: "{{ item.docker_host | default(lookup('env', 'DOCKER_HOST') or 'unix://var/run/docker.sock') }}"
+        state: absent
+        force_kill: "{{ item.force_kill | default(true) }}"
+      register: server
+      with_items: "{{ molecule_yml.platforms }}"
+      async: 7200
+      poll: 0
+
+    - name: Wait for instance(s) deletion to complete
+      async_status:
+        jid: "{{ item.ansible_job_id }}"
+      register: docker_jobs
+      until: docker_jobs.finished
+      retries: 300
+      with_items: "{{ server.results }}"
+
+    - name: Delete docker network(s)
+      docker_network:
+        name: "{{ item }}"
+        docker_host: "{{ item.docker_host | default(lookup('env', 'DOCKER_HOST') or 'unix://var/run/docker.sock') }}"
+        state: absent
+      with_items: "{{ molecule_yml.platforms | molecule_get_docker_networks }}"

--- a/roles/lnls-ans-role-network/molecule/default/molecule.yml
+++ b/roles/lnls-ans-role-network/molecule/default/molecule.yml
@@ -1,0 +1,33 @@
+---
+dependency:
+  name: galaxy
+lint:
+  name: yamllint
+provisioner:
+  name: ansible
+  lint:
+    name: ansible-lint
+  inventory:
+    group_vars:
+      default_group:
+scenario:
+  name: default
+verifier:
+  name: testinfra
+  options:
+    verbose: true
+  lint:
+    name: flake8
+driver:
+  name: docker
+platforms:
+  - name: lnls-ans-role-network-instance
+    image: "${MOLECULE_DISTRO:-debian:stretch}"
+    command: ${MOLECULE_DOCKER_COMMAND:-'bash -c "while true; do sleep 10000; done"'}
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    pre_build_image: true
+    groups:
+      - default_group
+    dns_servers: ["${DNS_SERVER1}", "${DNS_SERVER2}"]

--- a/roles/lnls-ans-role-network/molecule/default/playbook.yml
+++ b/roles/lnls-ans-role-network/molecule/default/playbook.yml
@@ -1,0 +1,9 @@
+---
+- name: Converge
+  hosts: all
+
+  vars:
+    network_ignore_systemd_errors: true
+
+  roles:
+    - role: lnls-ans-role-network

--- a/roles/lnls-ans-role-network/molecule/default/tests/test_default.py
+++ b/roles/lnls-ans-role-network/molecule/default/tests/test_default.py
@@ -1,0 +1,14 @@
+import os
+# import pytest
+
+import testinfra.utils.ansible_runner
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('default_group')
+
+
+# @pytest.mark.parametrize('', [
+# ])
+def test_default(host):
+
+    assert True

--- a/roles/lnls-ans-role-network/playbook.yml
+++ b/roles/lnls-ans-role-network/playbook.yml
@@ -1,0 +1,6 @@
+---
+- hosts: all
+  become: true
+  tasks:
+  - import_role:
+      name: '{{playbook_dir}}'

--- a/roles/lnls-ans-role-network/tasks/main.yml
+++ b/roles/lnls-ans-role-network/tasks/main.yml
@@ -1,0 +1,26 @@
+---
+- name: Resolve platform specific vars
+  include_vars: '{{ item }}'
+  with_first_found:
+    - files:
+        - '{{ ansible_distribution }}-{{ ansible_distribution_release }}.yml'
+        - '{{ ansible_distribution }}.yml'
+        - '{{ ansible_os_family }}.yml'
+      ignore_errors: true
+      paths:
+        - '{{ role_path }}/vars'
+
+- name: Define Network packages
+  set_fact:
+    network_packages: "{{ __network_packages | default ([]) }}"
+  when: network_packages is not defined
+
+# Include Tasks
+- include_tasks: setup-RedHat.yml
+  when: ansible_os_family == 'RedHat'
+
+- include_tasks: setup-Debian.yml
+  when: ansible_os_family == 'Debian'
+
+- include_tasks: setup-network.yml
+  when: ansible_os_family == 'Debian'

--- a/roles/lnls-ans-role-network/tasks/setup-Debian.yml
+++ b/roles/lnls-ans-role-network/tasks/setup-Debian.yml
@@ -1,0 +1,21 @@
+---
+- name: Update apt cache
+  apt:
+    update_cache: true
+    cache_valid_time: 86400
+  become: true
+  register: apt_update_cache_result
+  until: apt_update_cache_result is success
+  retries: 5
+  delay: 2
+
+- name: Ensure Network packages are installed
+  apt:
+    name: "{{ network_packages }}"
+    state: present
+  become: true
+  register: apt_result
+  until: apt_result is success
+  retries: 5
+  delay: 2
+

--- a/roles/lnls-ans-role-network/tasks/setup-RedHat.yml
+++ b/roles/lnls-ans-role-network/tasks/setup-RedHat.yml
@@ -1,0 +1,10 @@
+---
+- name: Ensure Network packages are installed
+  package:
+    name: "{{ network_packages }}"
+    state: present
+  become: true
+  register: package_get_result
+  until: package_get_result is success
+  retries: 5
+  delay: 2

--- a/roles/lnls-ans-role-network/tasks/setup-network.yml
+++ b/roles/lnls-ans-role-network/tasks/setup-network.yml
@@ -1,0 +1,40 @@
+---
+# Check if the interfaces are already using auto DNS
+- name: Check value of ignore-auto-dns for interface {{ item.name }}
+  lineinfile:
+    path: "/etc/NetworkManager/system-connections/{{ item.name }}"
+    line: "ignore-auto-dns={{ item.ignore_auto_dns }}"
+    state: present
+  check_mode: yes
+  become: true
+  register: conn_ignore_auto_dns_rc
+  changed_when: false
+  with_items:
+    - "{{ network_interfaces }}"
+
+ # Filter conn_ignore_auto_dns to get a list of {interface_names, value to be changed, ignore_auto_dns value}
+- name: Create dict of names,ignore_auto_dns from checked files
+  set_fact:
+    conn_ignore_auto_dns: "{{ conn_ignore_auto_dns|default([]) + [ {'name': item.item.name, 'to_be_changed': item.changed, 'value': item.item.ignore_auto_dns} ] }}"
+  with_items: "{{ conn_ignore_auto_dns_rc.results }}"
+
+- name: Disable auto DNS for ipv4
+  command: nmcli con mod {{ item.name }} ipv4.ignore-auto-dns {{ item.value }}
+  become: true
+  with_items:
+    - "{{ conn_ignore_auto_dns }}"
+  when:
+    - item.to_be_changed | bool and item.value == "true"
+  notify: Restart Network Manager systemd service
+
+- name: Disable auto DNS for ipv6
+  command: nmcli con mod {{ item.name }} ipv6.ignore-auto-dns {{ item.value }}
+  become: true
+  with_items:
+    - "{{ conn_ignore_auto_dns }}"
+  when:
+    - item.to_be_changed | bool and item.value == "true"
+  notify: Restart Network Manager systemd service
+
+- name: Force handlers to run at this point
+  meta: flush_handlers

--- a/roles/lnls-ans-role-network/vars/Debian-buster.yml
+++ b/roles/lnls-ans-role-network/vars/Debian-buster.yml
@@ -1,0 +1,6 @@
+---
+__network_packages:
+  # - "network-manager{{ (pkg_network_manager_version | length > 0) | ternary('=' + pkg_network_manager_version, '') }}"
+  - "python-dbus{{ (pkg_python_dbus_version | length > 0) | ternary('=' + pkg_python_dbus_version, '') }}"
+  - "python3-dbus{{ (pkg_python3_dbus_version | length > 0) | ternary('=' + pkg_python3_dbus_version, '') }}"
+  - "libnm-glib-dev{{ (pkg_libnm_glib_dev_version | length > 0) | ternary('=' + pkg_libnm_glib_dev_version, '') }}"

--- a/roles/lnls-ans-role-network/vars/Debian-stretch.yml
+++ b/roles/lnls-ans-role-network/vars/Debian-stretch.yml
@@ -1,0 +1,6 @@
+---
+__network_packages:
+  # - "network-manager{{ (pkg_network_manager_version | length > 0) | ternary('=' + pkg_network_manager_version, '') }}"
+  - "python-dbus{{ (pkg_python_dbus_version  | length > 0) | ternary('=' + pkg_python_dbus_version, '') }}"
+  - "python3-dbus{{ (pkg_python3_dbus_version  | length > 0) | ternary('=' + pkg_python3_dbus_version, '') }}"
+  - "libnm-glib-dev{{ (pkg_libnm_glib_dev_version  | length > 0) | ternary('=' + pkg_libnm_glib_dev_version, '') }}"

--- a/roles/lnls-ans-role-network/vars/Debian.yml
+++ b/roles/lnls-ans-role-network/vars/Debian.yml
@@ -1,0 +1,6 @@
+---
+__network_packages:
+  - network-manager
+  - python-dbus
+  - python3-dbus
+  - libnm-glib-dev

--- a/roles/lnls-ans-role-network/vars/RedHat.yml
+++ b/roles/lnls-ans-role-network/vars/RedHat.yml
@@ -1,0 +1,7 @@
+---
+__network_packages:
+  # - "NetworkManager-glib{{ (pkg_network_manager_glib_version | length > 0) | ternary('=' + pkg_network_manager_glib_version, '') }}"
+  - "libnm-qt-devel.x86_64{{ (pkg_libnm_qt_devel_version  | length > 0) | ternary('=' + pkg_libnm_qt_devel_version, '') }}"
+  - "nm-connection-editor.x86_64{{ (pkg_nm_connection_editor_version  | length > 0) | ternary('=' + pkg_nm_connection_editor_version, '') }}"
+  - "libsemanage-python{{ (pkg_libsemanage_python_version  | length > 0) | ternary('=' + pkg_libsemanage_python_version, '') }}"
+  - "policycoreutils-python{{ (pkg_policycoreutils_python_version  | length > 0) | ternary('=' + pkg_policycoreutils_python_version, '') }}"

--- a/tasks-desktops.yml
+++ b/tasks-desktops.yml
@@ -1,5 +1,7 @@
 ---
 - import_role:
+    name: lnls-ans-role-network
+- import_role:
     name: lnls-ans-role-nvidia-driver
   when: global_import_nvidia_driver_role | default(false) | bool
 - import_role:


### PR DESCRIPTION
This PR will fix the issue with multiple DNS by effectively disabling the DNS coming from the TIC VLAN. @edupcoelho had already suggested this approach. I've just created the automation means for that. Be advised that if the interface name is different than `"TIC"`, the role will fail for that host, but you can change the interface name via `defaults/main.yml`

Please, test this role (against your own computer maybe, if it runs NetworkManager) to check if you can reach the names in both our domain and internet/intranet