### PR TITLE
Update service-ioc-as-ap with new currinfo iocs

### DIFF
--- a/playbooks-services/playbook-service-ioc-as-ap.yml
+++ b/playbooks-services/playbook-service-ioc-as-ap.yml
@@ -5,9 +5,11 @@
   vars:
     role_to_run: lnls-ans-role-ctrl-service
     services_to_run:
-      - sirius-ioc-li-di-charge.service
       - sirius-ioc-li-ap-energy.service
+      - sirius-ioc-li-ap-currinfo.service
+      - sirius-ioc-tb-ap-currinfo.service
       - sirius-ioc-bo-ap-currinfo.service
+      - sirius-ioc-ts-ap-currinfo.service
       - sirius-ioc-si-ap-currinfo.service
       - sirius-ioc-si-ap-currinfo-lifetime.service
       - sirius-ioc-tb-ap-posang.service


### PR DESCRIPTION
Before deploying with this PR merged we should run makefile target `service-ioc-as-ap-stop`!