### PR TITLE
Prepare configs for parallel FBP siriuspy package

### DIFF
--- a/Makefile_services.mk
+++ b/Makefile_services.mk
@@ -512,32 +512,60 @@ service-ioc-tb-ps-fams-start:
 		--extra-vars "services_to_run_corrs='' services_to_run_diags='' ctrl_service_state=started" \
 		-u sirius -k --ask-become-pass playbooks-services/playbook-service-ioc-tb-ps.yml
 
+service-ioc-tb-ps-dipoles-stop:
+	@echo "Stopping TB PS Dipoles IOC services"
+	@echo "Please enter password for sirius user."
+	ansible-playbook \
+		--extra-vars "services_to_run_quadrupoles='' services_to_run_corrs='' services_to_run_diags='' ctrl_service_state=stopped" \
+		-u sirius -k --ask-become-pass playbooks-services/playbook-service-ioc-tb-ps.yml
+
+service-ioc-tb-ps-dipoles-start:
+	@echo "Starting TB PS Dipoles IOC services"
+	@echo "Please enter password for sirius user."
+	ansible-playbook \
+		--extra-vars "services_to_run_quadrupoles='' services_to_run_corrs='' services_to_run_diags='' ctrl_service_state=stopped" \
+		-u sirius -k --ask-become-pass playbooks-services/playbook-service-ioc-tb-ps.yml
+
+service-ioc-tb-ps-quadrupoles-stop:
+	@echo "Stopping TB PS Quadrupoles IOC services"
+	@echo "Please enter password for sirius user."
+	ansible-playbook \
+		--extra-vars "services_to_run_dipoles='' services_to_run_corrs='' services_to_run_diags='' ctrl_service_state=stopped" \
+		-u sirius -k --ask-become-pass playbooks-services/playbook-service-ioc-tb-ps.yml
+
+service-ioc-tb-ps-quadrupoles-start:
+	@echo "Start TB PS Quadrupoles IOC services"
+	@echo "Please enter password for sirius user."
+	ansible-playbook \
+		--extra-vars "services_to_run_dipoles='' services_to_run_corrs='' services_to_run_diags='' ctrl_service_state=stopped" \
+		-u sirius -k --ask-become-pass playbooks-services/playbook-service-ioc-tb-ps.yml
+
 service-ioc-tb-ps-corrs-stop:
 	@echo "Stopping TB PS Corrector IOC services"
 	@echo "Please enter password for sirius user."
 	ansible-playbook \
-		--extra-vars "services_to_run_fams='' services_to_run_diags='' ctrl_service_state=stopped" \
+		--extra-vars "services_to_run_dipoles='' services_to_run_quadrupoles='' services_to_run_diags='' ctrl_service_state=stopped" \
 		-u sirius -k --ask-become-pass playbooks-services/playbook-service-ioc-tb-ps.yml
 
 service-ioc-tb-ps-corrs-start:
 	@echo "Starting TB PS Corrector IOC services"
 	@echo "Please enter password for sirius user."
 	ansible-playbook \
-		--extra-vars "services_to_run_fams='' services_to_run_diags='' ctrl_service_state=started" \
+		--extra-vars "services_to_run_dipoles='' services_to_run_quadrupoles='' services_to_run_diags='' ctrl_service_state=started" \
 		-u sirius -k --ask-become-pass playbooks-services/playbook-service-ioc-tb-ps.yml
 
 service-ioc-tb-ps-diags-stop:
 	@echo "Stopping TB PS Diagnostic IOC services"
 	@echo "Please enter password for sirius user."
 	ansible-playbook \
-		--extra-vars "services_to_run_fams='' services_to_run_corrs='' ctrl_service_state=stopped" \
+		--extra-vars "services_to_run_dipoles='' services_to_run_quadrupoles='' services_to_run_corrs='' ctrl_service_state=stopped" \
 		-u sirius -k --ask-become-pass playbooks-services/playbook-service-ioc-tb-ps.yml
 
 service-ioc-tb-ps-diags-start:
 	@echo "Starting TB PS Diagnostic IOC services"
 	@echo "Please enter password for sirius user."
 	ansible-playbook \
-		--extra-vars "services_to_run_fams='' services_to_run_corrs='' ctrl_service_state=started" \
+		--extra-vars "services_to_run_dipoles='' services_to_run_quadrupoles='' services_to_run_corrs='' ctrl_service_state=started" \
 		-u sirius -k --ask-become-pass playbooks-services/playbook-service-ioc-tb-ps.yml
 
 # -- BO

--- a/group_vars/all
+++ b/group_vars/all
@@ -18,7 +18,7 @@ pkg_version_phoebus: 4.6.3
 pkg_version_ctrl_sys_consts: v1.6.0
 pkg_version_mathphys: v2.0.0
 pkg_version_ethbridge_pru_serial: v2.5.0
-pkg_version_siriuspy: v2.6.1
+pkg_version_siriuspy: v2.7.0
 pkg_version_machine_applications: v3.13.0
 pkg_version_siriushla: v0.24.1
 pkg_sirius_scripts: v0.5.1

--- a/group_vars/con
+++ b/group_vars/con
@@ -20,7 +20,7 @@ global_network_role: false
 global_phoebus_role: false
 
 # Run respositories Role
-global_repositories_role: false
+global_repositories_role: true
 
 # Lists of users to create or delete
 users:

--- a/group_vars/control_room_FBP
+++ b/group_vars/control_room_FBP
@@ -1,3 +1,0 @@
----
-
-pkg_version_siriuspy: v2.7.0-FBP

--- a/group_vars/control_room_FBP
+++ b/group_vars/control_room_FBP
@@ -1,0 +1,3 @@
+---
+
+pkg_version_siriuspy: v2.6.1-FBP

--- a/group_vars/control_room_FBP
+++ b/group_vars/control_room_FBP
@@ -1,3 +1,3 @@
 ---
 
-pkg_version_siriuspy: v2.6.1-FBP
+pkg_version_siriuspy: v2.7.0-FBP

--- a/group_vars/fac_servers
+++ b/group_vars/fac_servers
@@ -1,0 +1,3 @@
+---
+
+pkg_version_siriuspy: v2.6.1-FBP

--- a/group_vars/fac_servers
+++ b/group_vars/fac_servers
@@ -1,3 +1,3 @@
 ---
 
-pkg_version_siriuspy: v2.7.0-FBP
+pkg_version_siriuspy: v2.7.0-LEGACY

--- a/group_vars/fac_servers
+++ b/group_vars/fac_servers
@@ -1,3 +1,3 @@
 ---
 
-pkg_version_siriuspy: v2.6.1-FBP
+pkg_version_siriuspy: v2.7.0-FBP

--- a/hosts
+++ b/hosts
@@ -152,8 +152,11 @@ ioc_li_ps_conv_srv_host=lnls449-linux
 
 # --- TB
 
-[ioc_tb_ps_fams_srv:vars]
-ioc_tb_ps_fams_srv_host=lnls451-linux
+[ioc_tb_ps_dips_srv:vars]
+ioc_tb_ps_dips_srv_host=lnls451-linux
+
+[ioc_tb_ps_quads_srv:vars]
+ioc_tb_ps_quads_srv_host=lnls451-linux
 
 [ioc_tb_ps_corrs_srv:vars]
 ioc_tb_ps_corrs_srv_host=lnls451-linux

--- a/hosts
+++ b/hosts
@@ -166,11 +166,8 @@ ioc_tb_ps_diags_srv_host=lnls451-linux
 
 # --- BO
 
-[ioc_bo_ps_dips_srv:vars]
-ioc_bo_ps_dips_srv_host=lnls451-linux
-
-[ioc_bo_ps_quads_srv:vars]
-ioc_bo_ps_quads_srv_host=lnls451-linux
+[ioc_bo_ps_fams_srv:vars]
+ioc_bo_ps_fams_srv_host=lnls451-linux
 
 [ioc_bo_ps_corrs_srv:vars]
 ioc_bo_ps_corrs_srv_host=lnls451-linux

--- a/hosts
+++ b/hosts
@@ -3,13 +3,13 @@ linac-opi1
 linac-opi2
 
 [control_room]
+lnls449-linux
 lnls452-linux
+lnls454-linux
 lnls455-linux
 
-[control_room_FBP]
-lnls449-linux
+[control_room_LEGACY]
 lnls451-linux
-lnls454-linux
 
 [fac_control_room]
 lnls209-linux  # fac-desktop

--- a/hosts
+++ b/hosts
@@ -65,7 +65,10 @@ ioc_ps_srv
 [ioc_li_ps_conv_srv:children]
 ioc_ps_srv
 
-[ioc_tb_ps_fams_srv:children]
+[ioc_tb_ps_dips_srv:children]
+ioc_ps_srv
+
+[ioc_tb_ps_quads_srv:children]
 ioc_ps_srv
 
 [ioc_tb_ps_corrs_srv:children]
@@ -160,8 +163,11 @@ ioc_tb_ps_diags_srv_host=lnls451-linux
 
 # --- BO
 
-[ioc_bo_ps_fams_srv:vars]
-ioc_bo_ps_fams_srv_host=lnls451-linux
+[ioc_bo_ps_dips_srv:vars]
+ioc_bo_ps_dips_srv_host=lnls451-linux
+
+[ioc_bo_ps_quads_srv:vars]
+ioc_bo_ps_quads_srv_host=lnls451-linux
 
 [ioc_bo_ps_corrs_srv:vars]
 ioc_bo_ps_corrs_srv_host=lnls451-linux

--- a/hosts
+++ b/hosts
@@ -113,6 +113,48 @@ ioc_ps_srv
 
 # === server host selection ===
 
+# --- previous config ---
+# lnls451-linux
+# 	FBP: tb_ps_quad, tb_ps_corrs, bo_ps_corrs, ts_ps_corrs
+# 	OTH: as_ps_dclinks, tb_ps_dips, bo_ps_fams, ts_ps_fams, si_ps_fams
+# 	GEN: as_ti, as_ap, li_ps, tb_ps_diags, bo_ps_diags, ts_ps_diags
+# lnls449-linux:
+# 	FBP: si_ps_trims_m12
+# 	OTH:
+# 	GEN: as_ap_sofb, li_ps_conv
+# lnlsfac-srv1:
+# 	FBP: si_ps_corrs
+# 	OTH:
+# 	GEN: as_pu_conv, si_ps_diags
+# lnls454-linux
+# 	FBP: si_ps_trims_c1234
+# 	OTH:
+# 	GEN:
+
+# --- current config 2020-07-11 ---
+# In this proposal, FBP and non-FBP PS IOCs run in separated
+# hosts. This is necessary so that two versions of siriuspy
+# maybe installed, since this is required for two versions
+# of installed UDC firmware.
+#
+# !!! THIS WORKAROUND IS TEMPORARY !!!
+#
+# lnls451-linux
+# 	FBP:
+# 	OTH: as_ps_dclinks, tb_ps_dips, bo_ps_fams, ts_ps_fams, si_ps_fams
+# 	GEN: as_ti, as_ap, li_ps, tb_ps_diags, bo_ps_diags, ts_ps_diags
+# lnls449-linux:
+# 	FBP: si_ps_trims_m12, ts_ps_corrs
+# 	OTH:
+# 	GEN: as_ap_sofb, li_ps_conv
+# lnlsfac-srv1:
+# 	FBP: si_ps_corrs, tb_ps_quad, tb_ps_corrs,
+# 	OTH:
+# 	GEN: as_pu_conv, si_ps_diags
+# lnls454-linux
+# 	FBP: si_ps_trims_c1234, bo_ps_corrs, ts_ps_corrs
+# 	GEN:
+
 # --- AS
 
 [ioc_as_ti_srv]
@@ -156,10 +198,10 @@ ioc_li_ps_conv_srv_host=lnls449-linux
 ioc_tb_ps_dips_srv_host=lnls451-linux
 
 [ioc_tb_ps_quads_srv:vars]
-ioc_tb_ps_quads_srv_host=lnls451-linux
+ioc_tb_ps_quads_srv_host=lnlsfac-srv1
 
 [ioc_tb_ps_corrs_srv:vars]
-ioc_tb_ps_corrs_srv_host=lnls451-linux
+ioc_tb_ps_corrs_srv_host=lnlsfac-srv1
 
 [ioc_tb_ps_diags_srv:vars]
 ioc_tb_ps_diags_srv_host=lnls451-linux
@@ -170,7 +212,7 @@ ioc_tb_ps_diags_srv_host=lnls451-linux
 ioc_bo_ps_fams_srv_host=lnls451-linux
 
 [ioc_bo_ps_corrs_srv:vars]
-ioc_bo_ps_corrs_srv_host=lnls451-linux
+ioc_bo_ps_corrs_srv_host=lnls454-linux
 
 [ioc_bo_ps_diags_srv:vars]
 ioc_bo_ps_diags_srv_host=lnls451-linux
@@ -181,7 +223,7 @@ ioc_bo_ps_diags_srv_host=lnls451-linux
 ioc_ts_ps_fams_srv_host=lnls451-linux
 
 [ioc_ts_ps_corrs_srv:vars]
-ioc_ts_ps_corrs_srv_host=lnls451-linux
+ioc_ts_ps_corrs_srv_host=lnls454-linux
 
 [ioc_ts_ps_diags_srv:vars]
 ioc_ts_ps_diags_srv_host=lnls451-linux

--- a/hosts
+++ b/hosts
@@ -3,11 +3,13 @@ linac-opi1
 linac-opi2
 
 [control_room]
+lnls452-linux
+lnls455-linux
+
+[control_room_FBP]
 lnls449-linux
 lnls451-linux
-lnls452-linux
 lnls454-linux
-lnls455-linux
 
 [fac_control_room]
 lnls209-linux  # fac-desktop

--- a/playbook-control-room-desktops-sirius.yml
+++ b/playbook-control-room-desktops-sirius.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: control_room:linac_opi:fac_control_room:fac_servers
+- hosts: control_room:linac_opi:fac_control_room:fac_servers:control_room_FBP
   remote_user: sirius
   become: true
 

--- a/playbook-control-room-desktops-sirius.yml
+++ b/playbook-control-room-desktops-sirius.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: control_room:linac_opi:fac_control_room:fac_servers:control_room_FBP
+- hosts: control_room:linac_opi:fac_control_room:fac_servers:control_room_LEGACY
   remote_user: sirius
   become: true
 

--- a/playbook-control-room-desktops.yml
+++ b/playbook-control-room-desktops.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: control_room:linac_opi:fac_control_room:fac_servers
+- hosts: control_room:linac_opi:fac_control_room:fac_servers:control_room_FBP
   remote_user: sirius
   become: true
 

--- a/playbook-control-room-desktops.yml
+++ b/playbook-control-room-desktops.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: control_room:linac_opi:fac_control_room:fac_servers:control_room_FBP
+- hosts: control_room:linac_opi:fac_control_room:fac_servers:control_room_LEGACY
   remote_user: sirius
   become: true
 

--- a/playbooks-services/playbook-service-ioc-tb-ps.yml
+++ b/playbooks-services/playbook-service-ioc-tb-ps.yml
@@ -5,8 +5,10 @@
   vars:
     role_to_run: lnls-ans-role-ctrl-service
 
-    services_to_run_fams:
+    services_to_run_dipoles:
       - sirius-ioc-tb-ps-dipoles.service
+
+    services_to_run_quadrupoles:
       - sirius-ioc-tb-ps-quadrupoles.service
 
     services_to_run_corrs:
@@ -17,16 +19,27 @@
 
   tasks:
 
-    - name: "Run {{ role_to_run }} role for TB fams"
+    - name: "Run {{ role_to_run }} role for TB dipoles"
       include_role:
         name: "{{ role_to_run }}"
       vars:
         ctrl_service_name: "'{{ item }}'"
       with_items:
-        - "{{ services_to_run_fams }}"
+        - "{{ services_to_run_dipoles }}"
       when:
-        - ansible_host == ioc_tb_ps_fams_srv_host
-        - services_to_run_fams is defined and services_to_run_fams | length > 0
+        - ansible_host == ioc_tb_ps_dips_srv_host
+        - services_to_run_dipoles is defined and services_to_run_dipoles | length > 0
+
+    - name: "Run {{ role_to_run }} role for TB quadrupoles"
+      include_role:
+        name: "{{ role_to_run }}"
+      vars:
+        ctrl_service_name: "'{{ item }}'"
+      with_items:
+        - "{{ services_to_run_quadrupoles }}"
+      when:
+        - ansible_host == ioc_tb_ps_quads_srv_host
+        - services_to_run_quadrupole is defined and services_to_run_quadrupoles | length > 0
 
     - name: "Run {{ role_to_run }} role for TB corrs"
       include_role:


### PR DESCRIPTION
so that we can cope with FBP UDCs (TB quads) running with updated BSMP spec while other UDCs (TB dips) running with temporarily deprecated spec.