### PR TITLE
Swap tasks in lnls-ans-role-repositories

### DIFF
--- a/roles/lnls-ans-role-repositories/tasks/setup-Debian.yml
+++ b/roles/lnls-ans-role-repositories/tasks/setup-Debian.yml
@@ -6,6 +6,15 @@
       - apt-transport-https
     state: present
     update_cache: true
+    # We only need this as we might have expired signatures
+    # that could prevent us from executing this. The next task
+    # should fix this is that's the case, is not, it will fail for
+    # some other reason
+    allow_unauthenticated: true
+  # In some cases, we might have an invalid signature, preventing
+  # us from executing this. Ignore failures here and if something
+  # doesn't work on the next task we deal with it manually
+  failed_when: true
   become: true
   register: apt_result
   until: apt_result is success

--- a/roles/lnls-ans-role-repositories/tasks/setup-Debian.yml
+++ b/roles/lnls-ans-role-repositories/tasks/setup-Debian.yml
@@ -1,17 +1,4 @@
 ---
-- name: Install dependency packages
-  apt:
-    name:
-      - gnupg
-      - apt-transport-https
-    state: present
-    update_cache: true
-  become: true
-  register: apt_result
-  until: apt_result is success
-  retries: 5
-  delay: 2
-
 - name: Import APT GPG keys by URL
   apt_key:
     url: "{{ item.url }}"
@@ -23,6 +10,19 @@
   become: true
   register: gpg_import_url
   until: gpg_import_url is success
+  retries: 5
+  delay: 2
+
+- name: Install dependency packages
+  apt:
+    name:
+      - gnupg
+      - apt-transport-https
+    state: present
+    update_cache: true
+  become: true
+  register: apt_result
+  until: apt_result is success
   retries: 5
   delay: 2
 

--- a/roles/lnls-ans-role-repositories/tasks/setup-Debian.yml
+++ b/roles/lnls-ans-role-repositories/tasks/setup-Debian.yml
@@ -1,4 +1,17 @@
 ---
+- name: Install dependency packages
+  apt:
+    name:
+      - gnupg
+      - apt-transport-https
+    state: present
+    update_cache: true
+  become: true
+  register: apt_result
+  until: apt_result is success
+  retries: 5
+  delay: 2
+
 - name: Import APT GPG keys by URL
   apt_key:
     url: "{{ item.url }}"
@@ -10,19 +23,6 @@
   become: true
   register: gpg_import_url
   until: gpg_import_url is success
-  retries: 5
-  delay: 2
-
-- name: Install dependency packages
-  apt:
-    name:
-      - gnupg
-      - apt-transport-https
-    state: present
-    update_cache: true
-  become: true
-  register: apt_result
-  until: apt_result is success
   retries: 5
   delay: 2
 

--- a/roles/lnls-ans-role-repositories/tasks/setup-Debian.yml
+++ b/roles/lnls-ans-role-repositories/tasks/setup-Debian.yml
@@ -14,7 +14,7 @@
   # In some cases, we might have an invalid signature, preventing
   # us from executing this. Ignore failures here and if something
   # doesn't work on the next task we deal with it manually
-  failed_when: true
+  failed_when: false
   become: true
   register: apt_result
   until: apt_result is success

--- a/tasks-desktops.yml
+++ b/tasks-desktops.yml
@@ -1,8 +1,8 @@
 ---
 - import_role:
-    name: lnls-ans-role-users
-- import_role:
     name: lnls-ans-role-repositories
+- import_role:
+    name: lnls-ans-role-users
   when: global_repositories_role | default(true) | bool
 - import_role:
     name: lnls-ans-role-network


### PR DESCRIPTION
- install repositories keys first. (workaround abandoned)