### PR TITLE
Updating tags for pru-serial485 and eth-bridge

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -17,7 +17,7 @@ pkg_version_phoebus: 4.6.3
 
 pkg_version_ctrl_sys_consts: v1.8.0
 pkg_version_pru_serial: v1.5.0
-pkg_version_ethbridge_pru_serial: v2.5.0
+pkg_version_ethbridge_pru_serial: v2.6.0
 pkg_version_siriuspy: v2.7.0
 pkg_version_machine_applications: v3.13.1
 pkg_version_siriushla: v0.26.0


### PR DESCRIPTION
Updating tags for latest release for pru-serial485 (v1.5.0) and eth-bridge-pru-serial485 (v2.6.0)

@xresende is there any other file to update?