### PR TITLE
group_vars/all: update libdbus version

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -70,7 +70,7 @@ pkg_version_epics_calc_dev: 3.7.1*
 pkg_version_epics_autosave_dev: 5.9*
 pkg_version_epics_seq_dev: 2.2.6*
 pkg_version_wmctrl: 1.07*
-pkg_version_libdbus_1_3: 1.10.28*
+pkg_version_libdbus_1_3: 1.10.*
 pkg_version_libffi6: 3.2.1*
 pkg_version_libffi_dev: 3.2.1*
 pkg_version_libfreetype6: 2.6.3*


### PR DESCRIPTION
So that deploy works in all debian stretch 9.11-9.13 versions without package downgrade.