### PR TITLE
Load EPICS Variables in Terminals via VNC

### DIFF
--- a/roles/lnls-ans-role-desktop-apps/files/skel/.vnc/xstartup
+++ b/roles/lnls-ans-role-desktop-apps/files/skel/.vnc/xstartup
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/bin/bash -l
 xrdb $HOME/.Xresources
 startxfce4 &

--- a/roles/lnls-ans-role-desktop-apps/files/skel/Desktop/sirius-terminal.desktop
+++ b/roles/lnls-ans-role-desktop-apps/files/skel/Desktop/sirius-terminal.desktop
@@ -2,6 +2,6 @@
 Type=Application
 Name=Terminal
 Icon=/usr/share/icons/Adwaita/48x48/apps/utilities-terminal.png
-Exec=/usr/bin/gnome-terminal -e "bash -l"
+Exec=/usr/bin/gnome-terminal
 StartupNotify=true
 Terminal=false

--- a/roles/lnls-ans-role-desktop-apps/files/skel/Desktop/sirius-terminal.desktop
+++ b/roles/lnls-ans-role-desktop-apps/files/skel/Desktop/sirius-terminal.desktop
@@ -2,6 +2,6 @@
 Type=Application
 Name=Terminal
 Icon=/usr/share/icons/Adwaita/48x48/apps/utilities-terminal.png
-Exec=/usr/bin/gnome-terminal
+Exec=/usr/bin/gnome-terminal -e "bash -l"
 StartupNotify=true
 Terminal=false


### PR DESCRIPTION
Make sure terminals created e by desktop icon loads environment variables needed by Epics.