### PR TITLE
.travis.yml: fix travis config warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 ---
-sudo: required
 language: python
+os: linux
+dist: xenial
+
 services:
   - docker
 
@@ -12,8 +14,7 @@ env:
     - DNS_SERVER2: 8.8.8.8
     - CI_TIME: false
     - CI_TRACE: false
-  matrix:
-
+  jobs:
     - MOLECULE_DISTRO: debian:buster
       BUILD_TYPE: default
       ROLE: lnls-ans-role-users


### PR DESCRIPTION
Warnings were:

root: deprecated key sudo (The key `sudo` has no effect anymore.)
root: missing dist, using the default xenial
root: missing os, using the default linux
env: key matrix is an alias for jobs, using jobs