### PR TITLE
lnls-ans-role-qt: fix deprecated apt looping action

### DIFF
--- a/roles/lnls-ans-role-qt/tasks/remove-qt-from-apt.yml
+++ b/roles/lnls-ans-role-qt/tasks/remove-qt-from-apt.yml
@@ -1,8 +1,32 @@
 ---
+# Construct a list of only the installed packages, as
+# apt will not support looping soon.
+- name: Gather package facts for Qt
+  package_facts:
+    manager: apt
+
+- name: Create list of Qt packages to be removed
+  set_fact:
+    qt_distro_packages_to_remove: "{{ qt_distro_packages_to_remove | default([]) |
+            list + [ item | regex_replace('=.*$', '') ] }}"
+  with_items:
+    - "{{ qt_distro_packages | default([]) | list }}"
+  when: "item | regex_replace('=.*$', '') in ansible_facts.packages"
+
+- name: Default Qt packages to remove variable to empty
+  set_fact:
+    qt_distro_packages_to_remove: []
+  when:
+    - qt_distro_packages_to_remove is not defined
+
+- name: Qt distro packages to be removed
+  debug:
+    msg: "qt_distro_packages_to_remove: {{ qt_distro_packages_to_remove }}"
+
 # Use a loop here, as we might fail if some package is missing
 - name: Ensure no Qt system versions are installed
   apt:
-    name: "{{ item | regex_replace('=.*$', '') }}"
+    name: "{{ qt_distro_packages_to_remove }}"
     state: absent
     purge: true
   become: true
@@ -11,5 +35,3 @@
   until: apt_result is success
   retries: 5
   delay: 2
-  with_items:
-    - "{{ qt_distro_packages }}"


### PR DESCRIPTION
The ansible warning was:

```
TASK [lnls-ans-role-qt : Ensure no Qt system versions are installed] ********************************************************************************************************
[DEPRECATION WARNING]: Invoking "apt" only once while using a loop via squash_actions is deprecated. Instead of using a loop to supply multiple items and specifying `name:
"{{ item | regex_replace('=.*$', '') }}"`, please use `name: ['{{ qt_distro_packages }}']` and remove the loop. This feature will be removed in version 2.11. Deprecation
warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
ok: [dig-testes.abtlus.org.br] => (item=['qt5-default', 'qttools5-dev-tools', 'sip-dev', 'python3-pyqt5.qtsvg', 'libqt5opengl5-dev', 'qt5-qmake', 'qtbase5-dev'])
```

This was tested by installing the package `qt5-default` and then running this role. The result was successfully as follows:

```
TASK [lnls-ans-role-qt : include_tasks] *************************************************************************************************************************************
included: /home/lerwys/Repos/lnls-ansible/roles/lnls-ans-role-qt/tasks/remove-qt-from-apt.yml for dig-testes.abtlus.org.br

TASK [lnls-ans-role-qt : Gather package facts for Qt] ***********************************************************************************************************************
ok: [dig-testes.abtlus.org.br]

TASK [lnls-ans-role-qt : Create list of Qt packages to be removed] **********************************************************************************************************
ok: [dig-testes.abtlus.org.br] => (item=qt5-default=5.7.1*)
skipping: [dig-testes.abtlus.org.br] => (item=qttools5-dev-tools=5.7.1*) 
skipping: [dig-testes.abtlus.org.br] => (item=sip-dev=4.18.1*) 
skipping: [dig-testes.abtlus.org.br] => (item=python3-pyqt5.qtsvg=5.7*) 
ok: [dig-testes.abtlus.org.br] => (item=libqt5opengl5-dev=5.7.1*)
ok: [dig-testes.abtlus.org.br] => (item=qt5-qmake=5.7.1*)
ok: [dig-testes.abtlus.org.br] => (item=qtbase5-dev=5.7.1*)

TASK [lnls-ans-role-qt : Default Qt packages to remove variable to empty] ***************************************************************************************************
skipping: [dig-testes.abtlus.org.br]

TASK [lnls-ans-role-qt : Qt distro packages to be removed] ******************************************************************************************************************
ok: [dig-testes.abtlus.org.br] => 
  msg: 'qt_distro_packages_to_remove: [''qt5-default'', ''libqt5opengl5-dev'', ''qt5-qmake'', ''qtbase5-dev'']'

TASK [lnls-ans-role-qt : Ensure no Qt system versions are installed] ********************************************************************************************************
changed: [dig-testes.abtlus.org.br]
```