### PR TITLE
Pr add conda hlacon role to playbook

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -237,14 +237,6 @@ sirius_apps_hla_apps:
       INSTALL_DESIGNER_DIR: "{{ sirius_apps_hla_designer_dir }}"
     force_version: true
 
-  - name: High-Level Applications CONS
-    org_url: https://github.com/lnls-sirius
-    repo_name: pydm-opi
-    repo_version: "{{ pkg_version_pydm_opi }}"
-    clone_path: /tmp
-    install_via_makefile: true
-    force_version: true
-
 sirius_apps_hla_opis:
   - name: OPIs
     org_url: https://gitlab.cnpem.br/FACS

--- a/playbook-desktops.yml
+++ b/playbook-desktops.yml
@@ -41,6 +41,8 @@
       when: global_role_octave | default(true) | bool
     - role: lnls-ans-role-epics-mca
       when: global_role_epics_mca | default(true) | bool
+    - role: lnls-ans-role-conda
+    - role: lnls-ans-role-sirius-hlacon
     - role: lnls-ans-role-sirius-apps
     - role: lnls-ans-role-sirius-hla
     - role: lnls-ans-role-desktop-apps


### PR DESCRIPTION
This PR installs pydm-opi repository into a conda environment by using roles `lnls-ans-role-conda` and `lnls-ans-role-sirius-hlacon`