### PR TITLE
Pr add periodic travis build

### DIFF
--- a/.github/workflows/merge-travis.yml
+++ b/.github/workflows/merge-travis.yml
@@ -1,0 +1,25 @@
+name: Merge Upstream
+on:
+  schedule:
+    # scheduled for every night at midnight
+    - cron: '0 0 * * *'
+
+jobs:
+  merge-upstream:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out the codebase.
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Merge master branch into travis-build for triggering CI.
+        run: |
+          git branch --all
+          git config --list
+          git checkout travis-build
+          git merge --no-ff origin/master
+          git push origin travis-build
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/merge-travis.yml
+++ b/.github/workflows/merge-travis.yml
@@ -24,7 +24,7 @@ jobs:
           git branch --all
           git config --list
           git checkout travis-build
-          git merge --no-ff origin/master
+          git merge --strategy-option theirs --no-ff origin/master
           git push origin travis-build
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/merge-travis.yml
+++ b/.github/workflows/merge-travis.yml
@@ -14,6 +14,11 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Setup git name/email.
+        run: |
+          git config --global user.name "github-actions"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
       - name: Merge master branch into travis-build for triggering CI.
         run: |
           git branch --all


### PR DESCRIPTION
This was tested on my fork and it seems to be working ok: https://github.com/lerwys/lnls-ansible/runs/1183825269?check_suite_focus=true

The ideia is that this action will merge `master`into `travis-build` automatically every night at midnight, so travis will run our tests