### PR TITLE
{*meta.yml, README.md}: bump all ansible versions to 2.9

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: Top [meta] ansible role containing all Sirius roles
   company: CNPEM - LNLS
   license: BSD
-  min_ansible_version: 2.6
+  min_ansible_version: 2.9
 
   platforms:
     - name: Debian

--- a/roles/lnls-ans-role-clone-install/README.md
+++ b/roles/lnls-ans-role-clone-install/README.md
@@ -5,7 +5,7 @@ This Ansible role clone and install repositores.
 
 ## Requirements
 
-- ansible >= 2.6
+- ansible >= 2.9
 - molecule >= 3.0
 
 ## Role Variables

--- a/roles/lnls-ans-role-clone-install/meta/main.yml
+++ b/roles/lnls-ans-role-clone-install/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: Ansible role to clone and install repositories
   company: CNPEM - LNLS
   license: BSD
-  min_ansible_version: 2.6
+  min_ansible_version: 2.9
 
   platforms:
     - name: EL

--- a/roles/lnls-ans-role-conda/README.md
+++ b/roles/lnls-ans-role-conda/README.md
@@ -7,7 +7,7 @@ This Ansible role installs Conda
 
 ## Requirements
 
-- ansible >= 2.6
+- ansible >= 2.9
 - molecule >= 3.0
 
 ## Role Variables

--- a/roles/lnls-ans-role-conda/meta/main.yml
+++ b/roles/lnls-ans-role-conda/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: Ansible role to install Conda
   company: CNPEM - LNLS
   license: BSD
-  min_ansible_version: 2.6
+  min_ansible_version: 2.9
 
   platforms:
     - name: Debian

--- a/roles/lnls-ans-role-cs-studio/README.md
+++ b/roles/lnls-ans-role-cs-studio/README.md
@@ -7,7 +7,7 @@ This Ansible role configures CS-Studio for Sirius Light Source control machines.
 
 ## Requirements
 
-- ansible >= 2.6
+- ansible >= 2.9
 - molecule >= 3.0
 
 ## Role Variables

--- a/roles/lnls-ans-role-cs-studio/meta/main.yml
+++ b/roles/lnls-ans-role-cs-studio/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: Ansible role to install Control System Studio
   company: CNPEM - LNLS
   license: BSD
-  min_ansible_version: 2.6
+  min_ansible_version: 2.9
 
   platforms:
     - name: Debian

--- a/roles/lnls-ans-role-ctrl-service/README.md
+++ b/roles/lnls-ans-role-ctrl-service/README.md
@@ -5,7 +5,7 @@ This Ansible role configures services for Sirius Light Source control machines.
 
 ## Requirements
 
-- ansible >= 2.6
+- ansible >= 2.9
 - molecule >= 3.0
 
 ## Role Variables

--- a/roles/lnls-ans-role-ctrl-service/meta/main.yml
+++ b/roles/lnls-ans-role-ctrl-service/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: Ansible role to control services
   company: CNPEM - LNLS
   license: BSD
-  min_ansible_version: 2.6
+  min_ansible_version: 2.9
 
   platforms:
     - name: EL

--- a/roles/lnls-ans-role-desktop-apps/README.md
+++ b/roles/lnls-ans-role-desktop-apps/README.md
@@ -5,7 +5,7 @@ This Ansible role configures Desktop applications for Sirius Light Source contro
 
 ## Requirements
 
-- ansible >= 2.6
+- ansible >= 2.9
 - molecule >= 3.0
 
 ## Role Variables

--- a/roles/lnls-ans-role-desktop-apps/meta/main.yml
+++ b/roles/lnls-ans-role-desktop-apps/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: Ansible role to install Desktop Applications
   company: CNPEM - LNLS
   license: BSD
-  min_ansible_version: 2.6
+  min_ansible_version: 2.9
 
   platforms:
     - name: EL

--- a/roles/lnls-ans-role-desktop-settings/README.md
+++ b/roles/lnls-ans-role-desktop-settings/README.md
@@ -5,7 +5,7 @@ This Ansible role configures Desktop settings  for Sirius Light Source control m
 
 ## Requirements
 
-- ansible >= 2.6
+- ansible >= 2.9
 - molecule >= 3.0
 
 ## Role Variables

--- a/roles/lnls-ans-role-desktop-settings/meta/main.yml
+++ b/roles/lnls-ans-role-desktop-settings/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: Ansible role to install Desktop settings
   company: CNPEM - LNLS
   license: BSD
-  min_ansible_version: 2.6
+  min_ansible_version: 2.9
 
   platforms:
     - name: EL

--- a/roles/lnls-ans-role-epics-mca/README.md
+++ b/roles/lnls-ans-role-epics-mca/README.md
@@ -5,7 +5,7 @@ Ansible role to install EPICS MCA.
 
 ## Requirements
 
-- ansible >= 2.6
+- ansible >= 2.9
 - molecule >= 3.0
 
 ## Role Variables

--- a/roles/lnls-ans-role-epics-mca/meta/main.yml
+++ b/roles/lnls-ans-role-epics-mca/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: Ansible role to install EPICS base and extra packages
   company: CNPEM - LNLS
   license: BSD
-  min_ansible_version: 2.6
+  min_ansible_version: 2.9
 
   platforms:
     - name: Debian

--- a/roles/lnls-ans-role-epics/README.md
+++ b/roles/lnls-ans-role-epics/README.md
@@ -7,7 +7,7 @@ This Ansible role install EPICS packages.
 
 ## Requirements
 
-- ansible >= 2.6
+- ansible >= 2.9
 - molecule >= 3.0
 
 ## Role Variables

--- a/roles/lnls-ans-role-epics/meta/main.yml
+++ b/roles/lnls-ans-role-epics/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: Ansible role to install EPICS base and extra packages
   company: CNPEM - LNLS
   license: BSD
-  min_ansible_version: 2.6
+  min_ansible_version: 2.9
 
   platforms:
     - name: Debian

--- a/roles/lnls-ans-role-epics7/README.md
+++ b/roles/lnls-ans-role-epics7/README.md
@@ -5,7 +5,7 @@ This Ansible role configures EPICS 7 for Sirius Light Source control machines.
 
 ## Requirements
 
-- ansible >= 2.6
+- ansible >= 2.9
 - molecule >= 3.0
 
 ## Role Variables

--- a/roles/lnls-ans-role-epics7/meta/main.yml
+++ b/roles/lnls-ans-role-epics7/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: Ansible role to install EPICS 7
   company: CNPEM - LNLS
   license: BSD
-  min_ansible_version: 2.6
+  min_ansible_version: 2.9
 
   platforms:
     - name: Debian

--- a/roles/lnls-ans-role-java/README.md
+++ b/roles/lnls-ans-role-java/README.md
@@ -7,7 +7,7 @@ This Ansible role install Java packages.
 
 ## Requirements
 
-- ansible >= 2.6
+- ansible >= 2.9
 - molecule >= 3.0
 
 ## Role Variables

--- a/roles/lnls-ans-role-java/meta/main.yml
+++ b/roles/lnls-ans-role-java/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: Ansible role to install Java packages
   company: CNPEM - LNLS
   license: BSD
-  min_ansible_version: 2.6
+  min_ansible_version: 2.9
 
   platforms:
     - name: Debian

--- a/roles/lnls-ans-role-network/README.md
+++ b/roles/lnls-ans-role-network/README.md
@@ -5,7 +5,7 @@ This Ansible role configures some network parameters for Sirius Light Source con
 
 ## Requirements
 
-- ansible >= 2.6
+- ansible >= 2.9
 - molecule >= 3.0
 
 ## Role Variables

--- a/roles/lnls-ans-role-network/meta/main.yml
+++ b/roles/lnls-ans-role-network/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: Ansible role to configure Network
   company: CNPEM - LNLS
   license: BSD
-  min_ansible_version: 2.6
+  min_ansible_version: 2.9
 
   platforms:
     - name: EL

--- a/roles/lnls-ans-role-nfsclient/README.md
+++ b/roles/lnls-ans-role-nfsclient/README.md
@@ -7,7 +7,7 @@ This Ansible role configures some defaults users/groups for Sirius Light Source 
 
 ## Requirements
 
-- ansible >= 2.6
+- ansible >= 2.9
 - molecule >= 3.0
 
 ## Role Variables

--- a/roles/lnls-ans-role-nfsclient/meta/main.yml
+++ b/roles/lnls-ans-role-nfsclient/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: Ansible role to install python packages
   company: CNPEM - LNLS
   license: BSD
-  min_ansible_version: 2.6
+  min_ansible_version: 2.9
 
   platforms:
     - name: EL

--- a/roles/lnls-ans-role-nfsserver/README.md
+++ b/roles/lnls-ans-role-nfsserver/README.md
@@ -5,7 +5,7 @@ This Ansible role configures some defaults NFS server for Sirius Light Source co
 
 ## Requirements
 
-- ansible >= 2.6
+- ansible >= 2.9
 - molecule >= 3.0
 
 ## Role Variables

--- a/roles/lnls-ans-role-nfsserver/meta/main.yml
+++ b/roles/lnls-ans-role-nfsserver/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: Ansible role to install NFS server packages
   company: CNPEM - LNLS
   license: BSD
-  min_ansible_version: 2.6
+  min_ansible_version: 2.9
 
   platforms:
     - name: EL

--- a/roles/lnls-ans-role-ntp/meta/main.yml
+++ b/roles/lnls-ans-role-ntp/meta/main.yml
@@ -7,7 +7,7 @@ galaxy_info:
   description: NTP installation and configuration for Linux.
   company: "Midwestern Mac, LLC"
   license: "license (BSD, MIT)"
-  min_ansible_version: 2.6
+  min_ansible_version: 2.9
   platforms:
     - name: EL
       versions:

--- a/roles/lnls-ans-role-nvidia-driver/README.md
+++ b/roles/lnls-ans-role-nvidia-driver/README.md
@@ -5,7 +5,7 @@ This Ansible role configures the Nvidia driver for Sirius Light Source control m
 
 ## Requirements
 
-- ansible >= 2.6
+- ansible >= 2.9
 - molecule >= 3.0
 
 ## Role Variables

--- a/roles/lnls-ans-role-nvidia-driver/meta/main.yml
+++ b/roles/lnls-ans-role-nvidia-driver/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: Ansible role to install Nvidia driver
   company: CNPEM - LNLS
   license: BSD
-  min_ansible_version: 2.6
+  min_ansible_version: 2.9
 
   platforms:
     - name: EL

--- a/roles/lnls-ans-role-octave/README.md
+++ b/roles/lnls-ans-role-octave/README.md
@@ -7,7 +7,7 @@ Ansible role to install Octave.
 
 ## Requirements
 
-- ansible >= 2.6
+- ansible >= 2.9
 - molecule >= 3.0
 
 ## Role Variables

--- a/roles/lnls-ans-role-octave/meta/main.yml
+++ b/roles/lnls-ans-role-octave/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: Ansible role to install EPICS base and extra packages
   company: CNPEM - LNLS
   license: BSD
-  min_ansible_version: 2.6
+  min_ansible_version: 2.9
 
   platforms:
     - name: Debian

--- a/roles/lnls-ans-role-phoebus/README.md
+++ b/roles/lnls-ans-role-phoebus/README.md
@@ -5,7 +5,7 @@ This Ansible role configures Phoebus for Sirius Light Source control machines.
 
 ## Requirements
 
-- ansible >= 2.6
+- ansible >= 2.9
 - molecule >= 3.0
 
 ## Role Variables

--- a/roles/lnls-ans-role-phoebus/meta/main.yml
+++ b/roles/lnls-ans-role-phoebus/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: Ansible role to install Phoebus
   company: CNPEM - LNLS
   license: BSD
-  min_ansible_version: 2.6
+  min_ansible_version: 2.9
 
   platforms:
     - name: Debian

--- a/roles/lnls-ans-role-pydm/README.md
+++ b/roles/lnls-ans-role-pydm/README.md
@@ -5,7 +5,7 @@ This Ansible role configures some defaults PyDM for Sirius Light Source control 
 
 ## Requirements
 
-- ansible >= 2.6
+- ansible >= 2.9
 - molecule >= 3.0
 
 ## Role Variables

--- a/roles/lnls-ans-role-pydm/meta/main.yml
+++ b/roles/lnls-ans-role-pydm/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: Ansible role to install PyDM Package
   company: CNPEM - LNLS
   license: BSD
-  min_ansible_version: 2.6
+  min_ansible_version: 2.9
 
   platforms:
     - name: EL

--- a/roles/lnls-ans-role-python/README.md
+++ b/roles/lnls-ans-role-python/README.md
@@ -5,7 +5,7 @@ This Ansible role install python and related packages for Sirius Light Source co
 
 ## Requirements
 
-- ansible >= 2.6
+- ansible >= 2.9
 - molecule >= 3.0
 
 ## Role Variables

--- a/roles/lnls-ans-role-python/meta/main.yml
+++ b/roles/lnls-ans-role-python/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: Ansible role to install python packages
   company: CNPEM - LNLS
   license: BSD
-  min_ansible_version: 2.6
+  min_ansible_version: 2.9
 
   platforms:
     - name: EL

--- a/roles/lnls-ans-role-qt/README.md
+++ b/roles/lnls-ans-role-qt/README.md
@@ -5,7 +5,7 @@ This Ansible role configures some defaults Qt configurations for Sirius Light So
 
 ## Requirements
 
-- ansible >= 2.6
+- ansible >= 2.9
 - molecule >= 3.0
 
 ## Role Variables

--- a/roles/lnls-ans-role-qt/meta/main.yml
+++ b/roles/lnls-ans-role-qt/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: Ansible role to install Qt packages
   company: CNPEM - LNLS
   license: BSD
-  min_ansible_version: 2.6
+  min_ansible_version: 2.9
 
   platforms:
     - name: EL

--- a/roles/lnls-ans-role-repositories/README.md
+++ b/roles/lnls-ans-role-repositories/README.md
@@ -7,7 +7,7 @@ This Ansible role enables the Debian NSLS-II repositories.
 
 ## Requirements
 
-- ansible >= 2.6
+- ansible >= 2.9
 - molecule >= 3.0
 
 ## Role Variables

--- a/roles/lnls-ans-role-repositories/meta/main.yml
+++ b/roles/lnls-ans-role-repositories/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: Ansible role to install epics packages
   company: CNPEM - LNLS
   license: BSD
-  min_ansible_version: 2.6
+  min_ansible_version: 2.9
 
   platforms:
     - name: Debian

--- a/roles/lnls-ans-role-sirius-apps/README.md
+++ b/roles/lnls-ans-role-sirius-apps/README.md
@@ -5,7 +5,7 @@ This Ansible role configures some defaults Sirius High Level Applications for Si
 
 ## Requirements
 
-- ansible >= 2.6
+- ansible >= 2.9
 - molecule >= 3.0
 
 ## Role Variables

--- a/roles/lnls-ans-role-sirius-apps/meta/main.yml
+++ b/roles/lnls-ans-role-sirius-apps/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: Ansible role to install Sirius Apps packages
   company: CNPEM - LNLS
   license: BSD
-  min_ansible_version: 2.6
+  min_ansible_version: 2.9
 
   platforms:
     - name: EL

--- a/roles/lnls-ans-role-sirius-bbb/README.md
+++ b/roles/lnls-ans-role-sirius-bbb/README.md
@@ -5,7 +5,7 @@ This Ansible role configures Bunch-by-Bunch Feedback system for Sirius Light Sou
 
 ## Requirements
 
-- ansible >= 2.6
+- ansible >= 2.9
 - molecule >= 3.0
 
 ## Role Variables

--- a/roles/lnls-ans-role-sirius-bbb/meta/main.yml
+++ b/roles/lnls-ans-role-sirius-bbb/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: Ansible role to install Sirius BBB
   company: CNPEM - LNLS
   license: BSD
-  min_ansible_version: 2.6
+  min_ansible_version: 2.9
 
   platforms:
     - name: EL

--- a/roles/lnls-ans-role-sirius-hla/README.md
+++ b/roles/lnls-ans-role-sirius-hla/README.md
@@ -5,7 +5,7 @@ This Ansible role configures some defaults Sirius High Level Applications for Si
 
 ## Requirements
 
-- ansible >= 2.6
+- ansible >= 2.9
 - molecule >= 3.0
 
 ## Role Variables

--- a/roles/lnls-ans-role-sirius-hla/meta/main.yml
+++ b/roles/lnls-ans-role-sirius-hla/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: Ansible role to install Sirius HLA Apps packages
   company: CNPEM - LNLS
   license: BSD
-  min_ansible_version: 2.6
+  min_ansible_version: 2.9
 
   platforms:
     - name: EL

--- a/roles/lnls-ans-role-sirius-hlacon/meta/main.yml
+++ b/roles/lnls-ans-role-sirius-hlacon/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: Ansible role to install Sirius HLA CONS Apps packages
   company: CNPEM - LNLS
   license: BSD
-  min_ansible_version: 2.6
+  min_ansible_version: 2.9
 
   platforms:
     - name: EL

--- a/roles/lnls-ans-role-users/README.md
+++ b/roles/lnls-ans-role-users/README.md
@@ -7,7 +7,7 @@ This Ansible role configures some defaults users/groups for Sirius Light Source 
 
 ## Requirements
 
-- ansible >= 2.6
+- ansible >= 2.9
 - molecule >= 3.0
 
 ## Role Variables

--- a/roles/lnls-ans-role-users/meta/main.yml
+++ b/roles/lnls-ans-role-users/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: Ansible role to create users/groups
   company: CNPEM - LNLS
   license: BSD
-  min_ansible_version: 2.6
+  min_ansible_version: 2.9
 
   platforms:
     - name: EL

--- a/roles/lnls-ans-role-visual-studio-code/meta/main.yml
+++ b/roles/lnls-ans-role-visual-studio-code/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: Role for installing the Visual Studio Code IDE.
   company: GantSign Ltd.
   license: MIT
-  min_ansible_version: 2.6
+  min_ansible_version: 2.9
   platforms:
     - name: EL
       versions:

--- a/roles/lnls-ans-role-zabbix/README.md
+++ b/roles/lnls-ans-role-zabbix/README.md
@@ -5,7 +5,7 @@ This Ansible role configures Zabbix for Sirius Light Source control machines.
 
 ## Requirements
 
-- ansible >= 2.6
+- ansible >= 2.9
 - molecule >= 3.0
 
 ## Role Variables

--- a/roles/lnls-ans-role-zabbix/meta/main.yml
+++ b/roles/lnls-ans-role-zabbix/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: Ansible role to install Zabbix agent
   company: CNPEM - LNLS
   license: BSD
-  min_ansible_version: 2.6
+  min_ansible_version: 2.9
 
   platforms:
     - name: Debian


### PR DESCRIPTION
We need some 2.9 features for some roles, as new syntax is used

The following commands were issued to fix that:

sed -i -e 's/min_ansible_version: 2.6/min_ansible_version: 2.9/g' $(grep -RlIi "min_ansible_version:")
sed -i -e 's/ansible >= 2.6/ansible >= 2.9/g' $(grep -RlIi "ansible >= 2.6")