### PR TITLE
dynamic imported roles

### DIFF
--- a/playbooks/playbook-desktops.yml
+++ b/playbooks/playbook-desktops.yml
@@ -21,10 +21,7 @@
       when: global_network_role | default(true) | bool
     - role: lnls-ans-role-nvidia-driver
       when: global_import_nvidia_driver_role | default(false) | bool
-    - role: lnls-ans-role-glusterfs
-      when: "'control_room_all' in group_names"
     - role: lnls-ans-role-ntp
-    - role: lnls-ans-role-nfsclient
     - role: lnls-ans-role-zabbix
     - role: lnls-ans-role-python
     - role: lnls-ans-role-epics
@@ -52,3 +49,10 @@
       when: global_role_desktop_settings | default(true) | bool
     - role: lnls-ans-role-visual-studio-code
       when: global_role_visual_studio | default(false) | bool
+
+  tasks:
+    - include_role:
+        name: "lnls-ans-role-glusterfs"
+      when: "'control_room_all' in group_names"
+    - include_role:
+        name: "lnls-ans-role-nfsclient"


### PR DESCRIPTION
The glusterfs role must be dynamically imported.
The roles **lnls-ans-role-glusterfs** and **lnls-ans-role-nfsclient** were moved to `tasks` and are being imported using `include_role`. 

https://docs.ansible.com/ansible/latest/user_guide/playbooks_reuse_roles.html#including-roles-dynamic-reuse