### PR TITLE
Fix group_vars location problems due to the current molecule setup

### DIFF
--- a/.ci_build.sh
+++ b/.ci_build.sh
@@ -23,20 +23,26 @@ case "${CI_TRACE}" in
         set -x ;;
 esac
 
+if [ -z "${ANSIBLE_INVENTORY}" ] || [ ! -d "${ANSIBLE_INVENTORY}/group_vars" ]; then
+
+   [ ! -z "${ANSIBLE_INVENTORY}" ] && \
+       echo "group_vars/ not found at \"${ANSIBLE_INVENTORY}\", using default value"
+
+    ANSIBLE_INVENTORY="inventories/sirius"
+fi
+
+ln --verbose --symbolic ${ANSIBLE_INVENTORY}/group_vars .
+
 case "${BUILD_TYPE}" in
     default)
         echo "Running default molecule test" >&2
         ${CI_TIME} \
-            mkdir -p roles/${ROLE}/group_vars && \
-            cp --verbose inventories/sirius/group_vars/all roles/${ROLE}/group_vars/all && \
             cd roles/${ROLE} && \
             molecule test
         ;;
     debug)
         echo "Running debug molecule test" >&2
         ${CI_TIME} \
-            mkdir -p roles/${ROLE}/group_vars && \
-            cp --verbose inventories/sirius/group_vars/all roles/${ROLE}/group_vars/all && \
             cd roles/${ROLE} && \
             molecule --debug test
         ;;


### PR DESCRIPTION
The current molecule setup was not compatible with this script and after the inventory changes the problem became apparent.
I've removed the code because in reality it was not doing anything useful.
```bash
            mkdir -p roles/${ROLE}/group_vars && \
            cp --verbose inventories/sirius/group_vars/all roles/${ROLE}/group_vars/all && \
```
There are other approaches for this, but they all require several changes throughout the code.

In order for it to work as originally expected we would have to change `../../../../group_vars/` -> `../../group_vars/`, but that would break local molecule executions.

https://github.com/lnls-sirius/lnls-ansible/blob/master/roles/lnls-ans-role-users/molecule/default/molecule.yml#L13
https://github.com/lnls-sirius/lnls-ansible/blob/master/roles/lnls-ans-role-users/molecule/default/converge.yml

The solution I propose, at least for now, is to create a symbolic link emulating the expected directory structure with the ability to configure the inventory via environment variables.
