### PR TITLE
HLA packages on Debian 11

### DIFF
--- a/roles/lnls-ans-role-repositories/vars/Debian-bullseye.yml
+++ b/roles/lnls-ans-role-repositories/vars/Debian-bullseye.yml
@@ -1,0 +1,39 @@
+---
+# APT repositories
+__repository_keys:
+  - name: Debian NSLS2 key
+    url: https://epicsdeb.bnl.gov/debian/repo-key.pub
+    keyring: /etc/apt/trusted.gpg.d/nsls2-epics-debian.gpg
+
+  - name: Debian VSCode key
+    url: https://packages.microsoft.com/keys/microsoft.asc
+    keyring: /etc/apt/trusted.gpg.d/vscode-debian.gpg
+
+__repository_apt:
+  - name: NSLS2 EPICS debian repository
+    # expiration date: 2022-07-07
+    baseurl: "deb https://epicsdeb.bnl.gov/debian stretch main contrib"
+    description: "NSLS-II Debian EPICS repository"
+    file: nsls2-epics-debian
+    state: present
+
+  - name: NSLS2 EPICS debian repository sources
+    # expiration date: 2022-07-07
+    baseurl: "deb-src https://epicsdeb.bnl.gov/debian stretch main contrib"
+    description: "NSLS-II Debian EPICS repository"
+    file: nsls2-epics-debian-src
+    state: present
+
+  - name: Debian VScode
+    baseurl: "deb [arch=amd64] https://packages.microsoft.com/repos/code stable main"
+    description: "Debian Stretch VScode"
+    file: debian-vscode
+    state: present
+
+   # Contains dependencies for the edm-dev package which are not present in the bullseye repositorires
+  - name: Debian Stretch Main
+    baseurl: "deb http://deb.debian.org/debian stretch main"
+    description: "Debian Stretch Main"
+    file: debian-stretch-main
+    state: present
+

--- a/roles/lnls-ans-role-repositories/vars/Debian-bullseye.yml
+++ b/roles/lnls-ans-role-repositories/vars/Debian-bullseye.yml
@@ -36,4 +36,3 @@ __repository_apt:
     description: "Debian Stretch Main"
     file: debian-stretch-main
     state: present
-


### PR DESCRIPTION
This change will allow the installation of the packages required for lnls-ans-role-sirius-hla role on Debian 11.
Basically, a var file named Debian-bullseye.yml was created for lnls-ans-role-repositories role to include the repositories required for the installation of edm-dev and other tools on Debian 11.