### PR TITLE
conda installation role now is supported on Bullseye

### DIFF
--- a/roles/lnls-ans-role-conda/meta/main.yml
+++ b/roles/lnls-ans-role-conda/meta/main.yml
@@ -12,6 +12,7 @@ galaxy_info:
         - stretch
         - jessie
         - buster
+        - bullseye
     - name: Ubuntu
       versions:
         - xenial


### PR DESCRIPTION
The conda installation role was tested today on Debian 11 and works perfectly.