### PR TITLE
Fix deploy

### DIFF
--- a/inventories/sirius/group_vars/all
+++ b/inventories/sirius/group_vars/all
@@ -330,7 +330,7 @@ desktop_autofs_sirius_epics_screens: "{{ sirius_epics_screens }}"
 
 # === Visual Studio Extensions ===
 
-visual_studio_code_version: "1.73.1-1667967334"
+visual_studio_code_version: "1.75.1-1675893397"
 
 visual_studio_code_extensions:
   - coolbear.systemd-unit-file

--- a/roles/lnls-ans-role-nvidia-driver/vars/Debian-stretch.yml
+++ b/roles/lnls-ans-role-nvidia-driver/vars/Debian-stretch.yml
@@ -1,17 +1,17 @@
 ---
 __nvidia_repository_apt:
   - name: Debian contrib/non-free repository
-    baseurl: "deb http://deb.debian.org/debian stretch main contrib non-free"
+    baseurl: "deb http://archive.debian.org/debian stretch main contrib non-free"
     description: "Debian contrib/non-free repository"
     state: present
 
   - name: Debian contrib/non-free updates repository
-    baseurl: "deb http://deb.debian.org/debian stretch-updates main contrib non-free"
+    baseurl: "deb http://archive.debian.org/debian stretch-proposed-updates main contrib non-free"
     description: "Debian contrib/non-free updates repository"
     state: present
 
   - name: Debian contrib/non-free volatile repository
-    baseurl: "deb http://deb.debian.org/debian-security stretch/updates main contrib non-free"
+    baseurl: "deb http://archive.debian.org/debian-security stretch/updates main contrib non-free"
     description: "Debian contrib/non-free volatile repository"
     state: present
 

--- a/roles/lnls-ans-role-repositories/molecule/default/tests/test_ubuntu_xenial_based.py
+++ b/roles/lnls-ans-role-repositories/molecule/default/tests/test_ubuntu_xenial_based.py
@@ -12,8 +12,8 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     "repo",
     [
         "https://epicsdeb.bnl.gov/debian stretch/main",
-        "http://deb.debian.org/debian stretch/main",
-        "http://security.debian.org/debian-security stretch/updates/main",
+        "http://archive.debian.org/debian stretch/main",
+        "http://archive.debian.org/debian-security stretch/updates/main",
     ],
 )
 def test_repos(host, repo):

--- a/roles/lnls-ans-role-repositories/vars/Debian-bullseye.yml
+++ b/roles/lnls-ans-role-repositories/vars/Debian-bullseye.yml
@@ -35,10 +35,3 @@ __repository_apt:
     description: "Debian Bullseye-Backports Main"
     file: debian-bullseye-backports-main
     state: present
-
-   # Contains dependencies for the edm-dev package which are not present in the bullseye repositorires
-  - name: Debian Stretch Main
-    baseurl: "deb http://deb.debian.org/debian stretch main"
-    description: "Debian Stretch Main"
-    file: debian-stretch-main
-    state: present

--- a/roles/lnls-ans-role-repositories/vars/Debian-stretch.yml
+++ b/roles/lnls-ans-role-repositories/vars/Debian-stretch.yml
@@ -26,7 +26,7 @@ __repository_apt:
     state: present
 
   - name: Debian Stretch backports
-    baseurl: "deb http://deb.debian.org/debian stretch-backports main"
+    baseurl: "deb http://archive.debian.org/debian stretch-backports main"
     description: "Debian Stretch backports"
     file: debian-stretch-backports
     state: present

--- a/roles/lnls-ans-role-repositories/vars/Ubuntu-xenial.yml
+++ b/roles/lnls-ans-role-repositories/vars/Ubuntu-xenial.yml
@@ -35,25 +35,25 @@ __repository_apt:
     state: present
 
   - name: Debian Stretch repository
-    baseurl: "deb http://deb.debian.org/debian stretch main"
+    baseurl: "deb http://archive.debian.org/debian stretch main"
     description: "Debian Stretch repository"
     file: debian-stretch-main
     state: present
 
   - name: Debian Stretch repository sources
-    baseurl: "deb-src http://deb.debian.org/debian stretch main"
+    baseurl: "deb-src http://archive.debian.org/debian stretch main"
     description: "Debian Stretch repository"
     file: debian-stretch-main-src
     state: present
 
   - name: Debian Stretch security repository
-    baseurl: "deb http://security.debian.org/debian-security stretch/updates main"
+    baseurl: "deb http://archive.debian.org/debian-security stretch/updates main"
     description: "Debian Stretch security repository"
     file: debian-stretch-updates
     state: present
 
   - name: Debian Stretch security repository sources
-    baseurl: "deb-src http://security.debian.org/debian-security stretch/updates main"
+    baseurl: "deb-src http://archive.debian.org/debian-security stretch/updates main"
     description: "Debian Stretch security repository"
     file: debian-stretch-updates-src
     state: present


### PR DESCRIPTION
This PR fixes apt source lists generated during deploy for debian stretch hosts. Once debian stretch was moved to `archive` repositories, the new sources are:
```
http://deb.debian.org/debian/ stretch -> http://archive.debian.org/debian/ stretch
http://deb.debian.org/debian/ stretch-updates -> http://archive.debian.org/debian/ stretch-proposed-updates
http://security.debian.org/ stretch/updates -> http://archive.debian.org/debian-security stretch/updates
```

Also, it update vscode version.